### PR TITLE
Add docker integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ RUN go get -d && \
     go build -o /bin/ceph_exporter
 
 EXPOSE 9190
-CMD ["/bin/ceph_exporter"]
+ENTRYPOINT ["/bin/ceph_exporter"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,24 @@
 FROM ubuntu:14.04
 MAINTAINER Vaibhav Bhembre <vaibhav@digitalocean.com>
 
+ENV GOROOT /goroot
 ENV GOPATH /go
+ENV PATH $GOROOT/bin:$PATH
 ENV APPLOC $GOPATH/src/github.com/digitalocean/ceph_exporter
 
+ADD . $APPLOC
+
 RUN apt-get update && \
-    apt-get install build-essential
+    apt-get install -y build-essential git curl && \
     apt-get install -y librados-dev librbd-dev
+
+RUN \
+  mkdir -p /goroot && \
+  curl https://storage.googleapis.com/golang/go1.5.2.linux-amd64.tar.gz | tar xvzf - -C /goroot --strip-components=1
 
 WORKDIR $APPLOC
 RUN go get -d && \
-    go build -o /bin/ceph_exporter && \
-    rm -rf $GOPATH
+    go build -o /bin/ceph_exporter
 
-ENTRYPOINT ["/bin/ceph_exporter"
+EXPOSE 9190
+CMD ["/bin/ceph_exporter"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:14.04
+MAINTAINER Vaibhav Bhembre <vaibhav@digitalocean.com>
+
+ENV GOPATH /go
+ENV APPLOC $GOPATH/src/github.com/digitalocean/ceph_exporter
+
+RUN apt-get update && \
+    apt-get install build-essential
+    apt-get install -y librados-dev librbd-dev
+
+WORKDIR $APPLOC
+RUN go get -d && \
+    go build -o /bin/ceph_exporter && \
+    rm -rf $GOPATH
+
+ENTRYPOINT ["/bin/ceph_exporter"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,31 @@ go install
 
 A Makefile is provided in case you find a need for it.
 
+## Docker Image
+
+It is possible to run the exporter as a docker image. The port `9190` is
+exposed for running the default ceph exporter.
+
+The exporter needs your ceph configuration in order to establish communication with the monitors. You can either pass it in as an additional command or ideally you would just mount the directory containing both your `ceph.conf` and your user's keyring under the default `/etc/ceph` location that `Ceph` checks for.
+
+A sample run would look like:
+
+```bash
+$ docker build -t digitalocean/ceph_exporter .
+...
+<build takes place here>
+...
+$ docker run -v /etc/ceph:/etc/ceph -p=9190:9190 -it digitalocean/ceph_exporter
+```
+
+You would need to ensure your image can talk over to the monitors so if
+it needs access to your host's network stack you might need to add
+`--net=host` to the above command. It makes the port mapping redundant
+so the `-p` flag can be removed.
+
+Point your prometheus to scrape from `:9190` on your host now (or your port
+of choice if you decide to change it).
+
 ## Contributing
 
 Please refer to the [CONTRIBUTING](CONTRIBUTING.md) guide for more


### PR DESCRIPTION
- This should start ceph exporter on `9190` port as a default. It can be changed later if need be.

cc: @nickvanw @mdlayher @cagedmantis