### PR TITLE
Pick a default prometheus port for CephExporter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,5 @@ WORKDIR $APPLOC
 RUN go get -d && \
     go build -o /bin/ceph_exporter
 
-EXPOSE 9190
+EXPOSE 9128
 ENTRYPOINT ["/bin/ceph_exporter"]

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ We use Ceph's [official Golang client](https://github.com/ceph/go-ceph) to run c
 
 Name | Description | Default
 ---- | ---- | ----
-telemetry.addr | Host:Port pair to run exporter on | `*:9190`
+telemetry.addr | Host:Port pair to run exporter on | `*:9128`
 telemetry.path | URL Path for surfacing metrics to prometheus | `/metrics`
 ceph.config | Path to ceph configuration file | ""
 
@@ -36,7 +36,7 @@ A Makefile is provided in case you find a need for it.
 
 ## Docker Image
 
-It is possible to run the exporter as a docker image. The port `9190` is
+It is possible to run the exporter as a docker image. The port `9128` is
 exposed for running the default ceph exporter.
 
 The exporter needs your ceph configuration in order to establish communication with the monitors. You can either pass it in as an additional command or ideally you would just mount the directory containing both your `ceph.conf` and your user's keyring under the default `/etc/ceph` location that `Ceph` checks for.
@@ -48,7 +48,7 @@ $ docker build -t digitalocean/ceph_exporter .
 ...
 <build takes place here>
 ...
-$ docker run -v /etc/ceph:/etc/ceph -p=9190:9190 -it digitalocean/ceph_exporter
+$ docker run -v /etc/ceph:/etc/ceph -p=9128:9128 -it digitalocean/ceph_exporter
 ```
 
 You would need to ensure your image can talk over to the monitors so if
@@ -56,7 +56,7 @@ it needs access to your host's network stack you might need to add
 `--net=host` to the above command. It makes the port mapping redundant
 so the `-p` flag can be removed.
 
-Point your prometheus to scrape from `:9190` on your host now (or your port
+Point your prometheus to scrape from `:9128` on your host now (or your port
 of choice if you decide to change it).
 
 ## Contributing

--- a/exporter.go
+++ b/exporter.go
@@ -76,7 +76,7 @@ func (c *CephExporter) Collect(ch chan<- prometheus.Metric) {
 
 func main() {
 	var (
-		addr        = flag.String("telemetry.addr", ":9190", "host:port for ceph exporter")
+		addr        = flag.String("telemetry.addr", ":9128", "host:port for ceph exporter")
 		metricsPath = flag.String("telemetry.path", "/metrics", "URL path for surfacing collected metrics")
 
 		cephConfig = flag.String("ceph.config", "", "path to ceph config file")


### PR DESCRIPTION
Picking the next available port as per https://github.com/prometheus/prometheus/wiki/Default-port-allocations instead of an arbitrary one.

r: @mdlayher @cagedmantis