### PR TITLE
health: add client and recovery IO stats

### DIFF
--- a/collectors/health.go
+++ b/collectors/health.go
@@ -550,106 +550,119 @@ func (c *ClusterHealthCollector) collectRecoveryClientIO() error {
 		return err
 	}
 
-	var matched []string
 	sc := bufio.NewScanner(bytes.NewReader(buf))
 	for sc.Scan() {
 		line := strings.TrimSpace(sc.Text())
 
 		switch {
 		case strings.HasPrefix(line, "recovery io"):
-			matched = recoveryIORateRegex.FindStringSubmatch(line)
-			if len(matched) == 3 {
-				v, err := strconv.Atoi(matched[1])
-				if err != nil {
-					return err
-				}
-
-				switch strings.ToLower(matched[2]) {
-				case "gb":
-					v = v * 1e9
-				case "mb":
-					v = v * 1e6
-				case "kb":
-					v = v * 1e3
-				default:
-					return fmt.Errorf("can't parse units %q", matched[2])
-				}
-
-				c.RecoveryIORate.Set(float64(v))
-			}
-
-			matched = recoveryIOKeysRegex.FindStringSubmatch(line)
-			if len(matched) == 2 {
-				v, err := strconv.Atoi(matched[1])
-				if err != nil {
-					return err
-				}
-
-				c.RecoveryIOKeys.Set(float64(v))
-			}
-
-			matched = recoveryIOObjectsRegex.FindStringSubmatch(line)
-			if len(matched) == 2 {
-				v, err := strconv.Atoi(matched[1])
-				if err != nil {
-					return err
-				}
-
-				c.RecoveryIOObjects.Set(float64(v))
+			if err := c.collectRecoveryIO(line); err != nil {
+				return err
 			}
 		case strings.HasPrefix(line, "client io"):
-			matched = clientIOReadRegex.FindStringSubmatch(line)
-			if len(matched) == 3 {
-				v, err := strconv.Atoi(matched[1])
-				if err != nil {
-					return err
-				}
-
-				switch strings.ToLower(matched[2]) {
-				case "gb":
-					v = v * 1e9
-				case "mb":
-					v = v * 1e6
-				case "kb":
-					v = v * 1e3
-				default:
-					return fmt.Errorf("can't parse units %q", matched[2])
-				}
-
-				c.ClientIORead.Set(float64(v))
-			}
-
-			matched = clientIOWriteRegex.FindStringSubmatch(line)
-			if len(matched) == 3 {
-				v, err := strconv.Atoi(matched[1])
-				if err != nil {
-					return err
-				}
-
-				switch strings.ToLower(matched[2]) {
-				case "gb":
-					v = v * 1e9
-				case "mb":
-					v = v * 1e6
-				case "kb":
-					v = v * 1e3
-				default:
-					return fmt.Errorf("can't parse units %q", matched[2])
-				}
-
-				c.ClientIOWrite.Set(float64(v))
-			}
-
-			matched = clientIOOpsRegex.FindStringSubmatch(line)
-			if len(matched) == 2 {
-				v, err := strconv.Atoi(matched[1])
-				if err != nil {
-					return err
-				}
-
-				c.ClientIOOps.Set(float64(v))
+			if err := c.collectClientIO(line); err != nil {
+				return err
 			}
 		}
+	}
+	return nil
+}
+
+func (c *ClusterHealthCollector) collectClientIO(clientStr string) error {
+	matched := clientIOReadRegex.FindStringSubmatch(clientStr)
+	if len(matched) == 3 {
+		v, err := strconv.Atoi(matched[1])
+		if err != nil {
+			return err
+		}
+
+		switch strings.ToLower(matched[2]) {
+		case "gb":
+			v = v * 1e9
+		case "mb":
+			v = v * 1e6
+		case "kb":
+			v = v * 1e3
+		default:
+			return fmt.Errorf("can't parse units %q", matched[2])
+		}
+
+		c.ClientIORead.Set(float64(v))
+	}
+
+	matched = clientIOWriteRegex.FindStringSubmatch(clientStr)
+	if len(matched) == 3 {
+		v, err := strconv.Atoi(matched[1])
+		if err != nil {
+			return err
+		}
+
+		switch strings.ToLower(matched[2]) {
+		case "gb":
+			v = v * 1e9
+		case "mb":
+			v = v * 1e6
+		case "kb":
+			v = v * 1e3
+		default:
+			return fmt.Errorf("can't parse units %q", matched[2])
+		}
+
+		c.ClientIOWrite.Set(float64(v))
+	}
+
+	matched = clientIOOpsRegex.FindStringSubmatch(clientStr)
+	if len(matched) == 2 {
+		v, err := strconv.Atoi(matched[1])
+		if err != nil {
+			return err
+		}
+
+		c.ClientIOOps.Set(float64(v))
+	}
+	return nil
+}
+
+func (c *ClusterHealthCollector) collectRecoveryIO(recoveryStr string) error {
+	matched := recoveryIORateRegex.FindStringSubmatch(recoveryStr)
+	if len(matched) == 3 {
+		v, err := strconv.Atoi(matched[1])
+		if err != nil {
+			return err
+		}
+
+		switch strings.ToLower(matched[2]) {
+		case "gb":
+			v = v * 1e9
+		case "mb":
+			v = v * 1e6
+		case "kb":
+			v = v * 1e3
+		default:
+			return fmt.Errorf("can't parse units %q", matched[2])
+		}
+
+		c.RecoveryIORate.Set(float64(v))
+	}
+
+	matched = recoveryIOKeysRegex.FindStringSubmatch(recoveryStr)
+	if len(matched) == 2 {
+		v, err := strconv.Atoi(matched[1])
+		if err != nil {
+			return err
+		}
+
+		c.RecoveryIOKeys.Set(float64(v))
+	}
+
+	matched = recoveryIOObjectsRegex.FindStringSubmatch(recoveryStr)
+	if len(matched) == 2 {
+		v, err := strconv.Atoi(matched[1])
+		if err != nil {
+			return err
+		}
+
+		c.RecoveryIOObjects.Set(float64(v))
 	}
 	return nil
 }

--- a/collectors/health_test.go
+++ b/collectors/health_test.go
@@ -284,6 +284,24 @@ func TestClusterHealthCollector(t *testing.T) {
 				regexp.MustCompile(`health_status 2`),
 			},
 		},
+		{
+			input: `
+$ sudo ceph -s
+    cluster eff51be8-938a-4afa-b0d1-7a580b4ceb37
+     health HEALTH_OK
+     monmap e3: 3 mons at {mon01,mon02,mon03}
+  recovery io 5779 MB/s, 4 keys/s, 1522 objects/s
+  client io 4273 kB/s rd, 2740 MB/s wr, 2863 op/s
+`,
+			regexes: []*regexp.Regexp{
+				regexp.MustCompile(`recovery_io_bytes 5.779e`),
+				regexp.MustCompile(`recovery_io_keys 4`),
+				regexp.MustCompile(`recovery_io_objects 1522`),
+				regexp.MustCompile(`client_io_ops 2863`),
+				regexp.MustCompile(`client_io_read_bytes 4.273e`),
+				regexp.MustCompile(`client_io_write_bytes 2.74e`),
+			},
+		},
 	} {
 		func() {
 			collector := NewClusterHealthCollector(NewNoopConn(tt.input))


### PR DESCRIPTION
This adds 6 more stats to the ceph exporter. In most recent stable `hammer (v0.94.5)` both the client and recovery I/O is not present in the cluster status JSON. It's available only in the plain output. This adds a new function we use to scan through that status and extract relevant values.

---

r: @mdlayher @cagedmantis