### PR TITLE
health: Add support for IO ceph status changes in Jewel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,12 @@ before_install:
 install:
   - go get github.com/ceph/go-ceph
   - go get github.com/prometheus/client_golang/prometheus
+  - go get golang.org/x/tools/cmd/cover
   - go get github.com/axw/gocov/gocov
+  - go get github.com/modocache/gover
   - go get github.com/mattn/goveralls
-  - if ! go get code.google.com/p/go.tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
 
 script:
-  - $HOME/gopath/bin/goveralls -service=travis-ci ./...
+  - go test -coverprofile=collectors.coverprofile ./collectors
+  - $HOME/gopath/bin/gover
+  - $HOME/gopath/bin/goveralls -coverprofile=gover.coverprofile -service travis-ci

--- a/collectors/health_test.go
+++ b/collectors/health_test.go
@@ -302,6 +302,26 @@ $ sudo ceph -s
 				regexp.MustCompile(`client_io_write_bytes 2.74e`),
 			},
 		},
+		{
+			input: `
+$ sudo ceph -s
+    cluster eff51be8-938a-4afa-b0d1-7a580b4ceb37
+     health HEALTH_OK
+     monmap e3: 3 mons at {mon01,mon02,mon03}
+  recovery io 5779 MB/s, 4 keys/s, 1522 objects/s
+  client io 4273 kB/s rd, 2740 MB/s wr, 2863 op/s rd, 5847 op/s wr
+`,
+			regexes: []*regexp.Regexp{
+				regexp.MustCompile(`recovery_io_bytes 5.779e`),
+				regexp.MustCompile(`recovery_io_keys 4`),
+				regexp.MustCompile(`recovery_io_objects 1522`),
+				regexp.MustCompile(`client_io_read_bytes 4.273e`),
+				regexp.MustCompile(`client_io_write_bytes 2.74e`),
+				regexp.MustCompile(`client_io_ops 8710`),
+				regexp.MustCompile(`client_io_read_ops 2863`),
+				regexp.MustCompile(`client_io_write_ops 5847`),
+			},
+		},
 	} {
 		func() {
 			collector := NewClusterHealthCollector(NewNoopConn(tt.input))


### PR DESCRIPTION
Jewel displays read and write client IOPS separately as seen below:

```
    cluster 1cf6c452-efe7-4a1f-80b6-a2506168b685
     health HEALTH_OK
     monmap e13: 3 mons at {mon01=10.123.1.1:6789/0,mon02=10.123.1.2:6789/0,mon03=10.123.1.3:6789/0}
            election epoch 258, quorum 0,1,2 mon01,mon02,mon03
     osdmap e76078: 100 osds: 100 up, 100 in
      pgmap v5396704: 10000 pgs, 1 pools, 1719 GB data, 523 kobjects
            3441 GB used, 146 TB / 150 TB avail
               10000 active+clean
  client io 2399 MB/s wr, 750 op/s rd, 38410 op/s wr
```

This adds support for that while maintaining backward compatibility for hammer and below. Fixes https://github.com/digitalocean/ceph_exporter/issues/15.

r: @nickvanw 