### PR TITLE
health: Fix conflict of "ops/s" with bandwidth units

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,6 @@ ENV GOPATH /go
 ENV PATH $GOROOT/bin:$PATH
 ENV APPLOC $GOPATH/src/github.com/digitalocean/ceph_exporter
 
-ADD . $APPLOC
-
 RUN apt-get update && \
     apt-get install -y build-essential git curl && \
     apt-get install -y librados-dev librbd-dev
@@ -16,6 +14,7 @@ RUN \
   mkdir -p /goroot && \
   curl https://storage.googleapis.com/golang/go1.5.2.linux-amd64.tar.gz | tar xvzf - -C /goroot --strip-components=1
 
+ADD . $APPLOC
 WORKDIR $APPLOC
 RUN go get -d && \
     go build -o /bin/ceph_exporter

--- a/collectors/health.go
+++ b/collectors/health.go
@@ -31,8 +31,8 @@ var (
 	recoveryIORateRegex    = regexp.MustCompile(`(\d+) (\w{2})/s`)
 	recoveryIOKeysRegex    = regexp.MustCompile(`(\d+) keys/s`)
 	recoveryIOObjectsRegex = regexp.MustCompile(`(\d+) objects/s`)
-	clientIOReadRegex      = regexp.MustCompile(`(\d+) (\w[bB])/s rd`)
-	clientIOWriteRegex     = regexp.MustCompile(`(\d+) (\w[bB])/s wr`)
+	clientIOReadRegex      = regexp.MustCompile(`(\d+) ([kKmMgG][bB])/s rd`)
+	clientIOWriteRegex     = regexp.MustCompile(`(\d+) ([kKmMgG][bB])/s wr`)
 	clientIOReadOpsRegex   = regexp.MustCompile(`(\d+) op/s rd`)
 	clientIOWriteOpsRegex  = regexp.MustCompile(`(\d+) op/s wr`)
 

--- a/collectors/health.go
+++ b/collectors/health.go
@@ -31,8 +31,8 @@ var (
 	recoveryIORateRegex    = regexp.MustCompile(`(\d+) (\w{2})/s`)
 	recoveryIOKeysRegex    = regexp.MustCompile(`(\d+) keys/s`)
 	recoveryIOObjectsRegex = regexp.MustCompile(`(\d+) objects/s`)
-	clientIOReadRegex      = regexp.MustCompile(`(\d+) (\w{2})/s rd`)
-	clientIOWriteRegex     = regexp.MustCompile(`(\d+) (\w{2})/s wr`)
+	clientIOReadRegex      = regexp.MustCompile(`(\d+) (\w[bB])/s rd`)
+	clientIOWriteRegex     = regexp.MustCompile(`(\d+) (\w[bB])/s wr`)
 	clientIOReadOpsRegex   = regexp.MustCompile(`(\d+) op/s rd`)
 	clientIOWriteOpsRegex  = regexp.MustCompile(`(\d+) op/s wr`)
 

--- a/collectors/health_test.go
+++ b/collectors/health_test.go
@@ -309,14 +309,12 @@ $ sudo ceph -s
      health HEALTH_OK
      monmap e3: 3 mons at {mon01,mon02,mon03}
   recovery io 5779 MB/s, 4 keys/s, 1522 objects/s
-  client io 4273 kB/s rd, 2740 MB/s wr, 2863 op/s rd, 5847 op/s wr
+  client io 2863 op/s rd, 5847 op/s wr
 `,
 			regexes: []*regexp.Regexp{
 				regexp.MustCompile(`recovery_io_bytes 5.779e`),
 				regexp.MustCompile(`recovery_io_keys 4`),
 				regexp.MustCompile(`recovery_io_objects 1522`),
-				regexp.MustCompile(`client_io_read_bytes 4.273e`),
-				regexp.MustCompile(`client_io_write_bytes 2.74e`),
 				regexp.MustCompile(`client_io_ops 8710`),
 				regexp.MustCompile(`client_io_read_ops 2863`),
 				regexp.MustCompile(`client_io_write_ops 5847`),


### PR DESCRIPTION
We had a collision with regex due to the new Jewel convention (`\w{2}` =~ `op` =~ `MB`) . The regex for extracting client B/W has been made much stricter now to adhere to this.

Additionally the test is modified so that this issue is more apparent by causing the test to fail without having any B/W values to bank on.

This should fix https://github.com/digitalocean/ceph_exporter/issues/17.