### PR TITLE
docker: support building librados against ceph Jewel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,14 @@ ENV GOPATH /go
 ENV PATH $GOROOT/bin:$PATH
 ENV APPLOC $GOPATH/src/github.com/digitalocean/ceph_exporter
 
+RUN apt-get install -y apt-transport-https
+
+RUN echo "deb https://download.ceph.com/debian-jewel trusty main" >> /etc/apt/sources.list
+
 RUN apt-get update && \
-    apt-get install -y build-essential git curl && \
-    apt-get install -y librados-dev librbd-dev
+    apt-get install -y build-essential git curl
+
+RUN apt-get install -y --force-yes librados-dev librbd-dev
 
 RUN \
   mkdir -p /goroot && \


### PR DESCRIPTION
Build `ceph_exporter` docker bin against the latest version of Ceph: Jewel.