### PR TITLE
health: fix osd_down metric

### DIFF
--- a/collectors/health_test.go
+++ b/collectors/health_test.go
@@ -204,16 +204,15 @@ func TestClusterHealthCollector(t *testing.T) {
 {
 	"osdmap": {
 		"osdmap": {
-			"num_osds": 0,
-			"num_up_osds": 0,
+			"num_osds": 20,
+			"num_up_osds": 10,
 			"num_in_osds": 0,
 			"num_remapped_pgs": 0
 		}
-	},
-	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "3/20 in osds are down"}]}
+	}
 }`,
 			regexes: []*regexp.Regexp{
-				regexp.MustCompile(`osds_down 3`),
+				regexp.MustCompile(`osds_down 10`),
 			},
 		},
 		{


### PR DESCRIPTION
Pull the OSD down values from the delta of total OSDs against the ones that are up, instead of reading this information from the summary.

r: @mdlayher 

Fixes https://github.com/digitalocean/ceph_exporter/issues/34.