### PR TITLE
Support ceph user other than admin

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -81,7 +81,7 @@ func main() {
 		metricsPath = flag.String("telemetry.path", "/metrics", "URL path for surfacing collected metrics")
 
 		cephConfig = flag.String("ceph.config", "", "path to ceph config file")
-		cephUser   = flag.String("ceph.user", "admin", "Ceph user to connect to cluster. The key file must be named ceph.client.<user>.keyring.")
+		cephUser   = flag.String("ceph.user", "admin", "Ceph user to connect to cluster.")
 	)
 	flag.Parse()
 

--- a/exporter.go
+++ b/exporter.go
@@ -81,7 +81,7 @@ func main() {
 		metricsPath = flag.String("telemetry.path", "/metrics", "URL path for surfacing collected metrics")
 
 		cephConfig = flag.String("ceph.config", "", "path to ceph config file")
-                cephUser = flag.String("ceph.user", "admin", "Ceph user to connect to cluster. The key file must be named ceph.client.<user>.keyring.")
+		cephUser   = flag.String("ceph.user", "admin", "Ceph user to connect to cluster. The key file must be named ceph.client.<user>.keyring.")
 	)
 	flag.Parse()
 

--- a/exporter.go
+++ b/exporter.go
@@ -81,10 +81,11 @@ func main() {
 		metricsPath = flag.String("telemetry.path", "/metrics", "URL path for surfacing collected metrics")
 
 		cephConfig = flag.String("ceph.config", "", "path to ceph config file")
+                cephUser = flag.String("ceph.user", "admin", "Ceph user to connect to cluster. The key file must be named ceph.client.<user>.keyring.")
 	)
 	flag.Parse()
 
-	conn, err := rados.NewConn()
+	conn, err := rados.NewConnWithUser(*cephUser)
 	if err != nil {
 		log.Fatalf("cannot create new ceph connection: %s", err)
 	}


### PR DESCRIPTION
Hi,

On my ceph cluster, I have created a monitoring user with only read permission. I don't want to use admin user to execute monitoring tasks.
I have made a little modification in order to support passing user as a a parameter to ceph_exporter:
`-ceph.user <user>`
ceph_exporter will look into ceph conf directory for a key file named `ceph.client.<user>.keyring`
