### PR TITLE
bug: fix installation of ceph libraries, add docker tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ dist: trusty
 go:
   - 1.5
 
+env:
+  - DOCKER_TAG=$TRAVIS_TAG
+
 before_install:
   - sudo apt-get update
   - sudo apt-get install -y librados-dev librbd-dev
@@ -26,5 +29,5 @@ script:
 after_success:
   - if [ "$TRAVIS_BRANCH" == "master" ]; then
     docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
-    docker push digitalocean/ceph_exporter;
+    docker push digitalocean/ceph_exporter:$DOCKER_TAG;
     fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ RUN apt-get update && \
 
 RUN echo "deb https://download.ceph.com/debian-jewel trusty main" >> /etc/apt/sources.list
 
-RUN apt-get install -y --force-yes librados-dev librbd-dev
+RUN apt-get update && \
+    apt-get install -y --force-yes librados-dev librbd-dev
 
 RUN \
   mkdir -p /goroot && \


### PR DESCRIPTION
This fixes the issue with the installation of librados and librbd Jewel libraries. It also adds docker tags that identifies each release separately. In future we should change it to release versions once we decide on how releases should look like.

r: @mdlayher 

Fixes https://github.com/digitalocean/ceph_exporter/issues/42.