### PR TITLE
travis: fix docker push, add default page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,12 @@ script:
   - go test -coverprofile=collectors.coverprofile ./collectors
   - $HOME/gopath/bin/gover
   - $HOME/gopath/bin/goveralls -coverprofile=gover.coverprofile -service travis-ci
-  - docker build -t digitalocean/ceph_exporter .
 
 after_success:
-  - if [ "$TRAVIS_BRANCH" == "master" ]; then
+  - export DOCKER_REPO="digitalocean/ceph_exporter"
+  - if [ ! -z "$TRAVIS_TAG" ]; then
+    docker build -t $DOCKER_REPO:$DOCKER_TAG .;
+    docker tag $DOCKER_REPO:$DOCKER_TAG $DOCKER_REPO:latest;
     docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
-    docker push digitalocean/ceph_exporter:$DOCKER_TAG;
+    docker push $DOCKER_REPO;
     fi

--- a/exporter.go
+++ b/exporter.go
@@ -108,7 +108,13 @@ func main() {
 
 	http.Handle(*metricsPath, prometheus.Handler())
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, *metricsPath, http.StatusMovedPermanently)
+		w.Write([]byte(`<html>
+			<head><title>Ceph Exporter</title></head>
+			<body>
+			<h1>Ceph Exporter</h1>
+			<p><a href='` + *metricsPath + `'>Metrics</a></p>
+			</body>
+			</html>`))
 	})
 
 	log.Printf("Starting ceph exporter on %q", *addr)


### PR DESCRIPTION
This changes docker image builds to only happen on tagged releases. Also adds a status page to root path.

