### PR TITLE
pool: remove error log when no pools present

### DIFF
--- a/collectors/pool_usage.go
+++ b/collectors/pool_usage.go
@@ -16,7 +16,6 @@ package collectors
 
 import (
 	"encoding/json"
-	"errors"
 	"log"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -209,10 +208,6 @@ func (p *PoolUsageCollector) collect() error {
 	stats := &cephPoolStats{}
 	if err := json.Unmarshal(buf, stats); err != nil {
 		return err
-	}
-
-	if len(stats.Pools) < 1 {
-		return errors.New("no pools found in the cluster to report stats on")
 	}
 
 	for _, pool := range stats.Pools {


### PR DESCRIPTION
If there's no pools created yet (which can be true after a ceph
cluster is initially created, but before any pools are present),
there'll be a log every minute "[ERROR] failed collecting pool
usage metrics: no pools found in the cluster to report stats on".

IMO that's not actually an error, it's just the way things are,
so doesn't really need to be reported.

Signed-off-by: Tim Serong <tserong@suse.com>