### PR TITLE
health: expose slow requests for luminous

### DIFF
--- a/collectors/health_test.go
+++ b/collectors/health_test.go
@@ -388,6 +388,24 @@ $ sudo ceph -s
 				regexp.MustCompile(`slow_requests{cluster="ceph"} 6`),
 			},
 		},
+		{
+			input: `
+{
+  "health": {
+    "checks": {
+      "REQUEST_SLOW": {
+        "severity": "HEALTH_WARN",
+        "summary": {
+          "message": "6 slow requests are blocked > 32 sec"
+        }
+      }
+    }
+  }
+}`,
+			regexes: []*regexp.Regexp{
+				regexp.MustCompile(`slow_requests{cluster="ceph"} 6`),
+			},
+		},
 	} {
 		func() {
 			collector := NewClusterHealthCollector(NewNoopConn(tt.input), "ceph")


### PR DESCRIPTION
Extract slow request information from health checks in ceph luminous. It's still compatible to older versions of ceph.

It's possible to add additional luminous metrics, i.e. stucked pgs, in the same way.