### PR TITLE
update /metrics handler to promhttp.Handler()

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -21,10 +21,10 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/digitalocean/ceph_exporter/collectors"
-
 	"github.com/ceph/go-ceph/rados"
+	"github.com/digitalocean/ceph_exporter/collectors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // CephExporter wraps all the ceph collectors and provides a single global
@@ -140,7 +140,7 @@ func main() {
 		prometheus.MustRegister(NewCephExporter(conn, "ceph"))
 	}
 
-	http.Handle(*metricsPath, prometheus.Handler())
+	http.Handle(*metricsPath, promhttp.Handler())
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`<html>
 			<head><title>Ceph Exporter</title></head>


### PR DESCRIPTION
Why this change is necessary?
This commit resolves issue #68 .

How will this change affect to the project?
[Prometheus](prometheus.io) has clearly mentioned in their code that this method is deprecated, use `promhttp.Handler()` instead. This is very similar to `prometheus.Handler()`. This will not have any major impact on the project.