### PR TITLE
More json add backfill

### DIFF
--- a/collectors/health.go
+++ b/collectors/health.go
@@ -567,47 +567,25 @@ func (c *ClusterHealthCollector) collect() error {
 		c.HealthStatus.Set(2)
 	}
 
+	c.DegradedObjectsCount.Set(stats.PGMap.DegradedObjects)
+	c.MisplacedObjectsCount.Set(stats.PGMap.MisplacedObjects)
 	var (
-		degradedRegex            = regexp.MustCompile(`([\d]+) pgs degraded`)
 		stuckDegradedRegex       = regexp.MustCompile(`([\d]+) pgs stuck degraded`)
-		uncleanRegex             = regexp.MustCompile(`([\d]+) pgs unclean`)
 		stuckUncleanRegex        = regexp.MustCompile(`([\d]+) pgs stuck unclean`)
-		undersizedRegex          = regexp.MustCompile(`([\d]+) pgs undersized`)
 		stuckUndersizedRegex     = regexp.MustCompile(`([\d]+) pgs stuck undersized`)
-		staleRegex               = regexp.MustCompile(`([\d]+) pgs stale`)
 		stuckStaleRegex          = regexp.MustCompile(`([\d]+) pgs stuck stale`)
 		slowRequestRegex         = regexp.MustCompile(`([\d]+) requests are blocked`)
 		slowRequestRegexLuminous = regexp.MustCompile(`([\d]+) slow requests are blocked`)
-		degradedObjectsRegex     = regexp.MustCompile(`recovery ([\d]+)/([\d]+) objects degraded`)
-		misplacedObjectsRegex    = regexp.MustCompile(`recovery ([\d]+)/([\d]+) objects misplaced`)
 	)
 
 	for _, s := range stats.Health.Summary {
-		matched := degradedRegex.FindStringSubmatch(s.Summary)
-		if len(matched) == 2 {
-			v, err := strconv.Atoi(matched[1])
-			if err != nil {
-				return err
-			}
-			c.DegradedPGs.Set(float64(v))
-		}
-
-		matched = stuckDegradedRegex.FindStringSubmatch(s.Summary)
+		matched := stuckDegradedRegex.FindStringSubmatch(s.Summary)
 		if len(matched) == 2 {
 			v, err := strconv.Atoi(matched[1])
 			if err != nil {
 				return err
 			}
 			c.StuckDegradedPGs.Set(float64(v))
-		}
-
-		matched = uncleanRegex.FindStringSubmatch(s.Summary)
-		if len(matched) == 2 {
-			v, err := strconv.Atoi(matched[1])
-			if err != nil {
-				return err
-			}
-			c.UncleanPGs.Set(float64(v))
 		}
 
 		matched = stuckUncleanRegex.FindStringSubmatch(s.Summary)
@@ -619,15 +597,6 @@ func (c *ClusterHealthCollector) collect() error {
 			c.StuckUncleanPGs.Set(float64(v))
 		}
 
-		matched = undersizedRegex.FindStringSubmatch(s.Summary)
-		if len(matched) == 2 {
-			v, err := strconv.Atoi(matched[1])
-			if err != nil {
-				return err
-			}
-			c.UndersizedPGs.Set(float64(v))
-		}
-
 		matched = stuckUndersizedRegex.FindStringSubmatch(s.Summary)
 		if len(matched) == 2 {
 			v, err := strconv.Atoi(matched[1])
@@ -635,15 +604,6 @@ func (c *ClusterHealthCollector) collect() error {
 				return err
 			}
 			c.StuckUndersizedPGs.Set(float64(v))
-		}
-
-		matched = staleRegex.FindStringSubmatch(s.Summary)
-		if len(matched) == 2 {
-			v, err := strconv.Atoi(matched[1])
-			if err != nil {
-				return err
-			}
-			c.StalePGs.Set(float64(v))
 		}
 
 		matched = stuckStaleRegex.FindStringSubmatch(s.Summary)
@@ -664,23 +624,6 @@ func (c *ClusterHealthCollector) collect() error {
 			c.SlowRequests.Set(float64(v))
 		}
 
-		matched = degradedObjectsRegex.FindStringSubmatch(s.Summary)
-		if len(matched) == 3 {
-			v, err := strconv.Atoi(matched[1])
-			if err != nil {
-				return err
-			}
-			c.DegradedObjectsCount.Set(float64(v))
-		}
-
-		matched = misplacedObjectsRegex.FindStringSubmatch(s.Summary)
-		if len(matched) == 3 {
-			v, err := strconv.Atoi(matched[1])
-			if err != nil {
-				return err
-			}
-			c.MisplacedObjectsCount.Set(float64(v))
-		}
 	}
 
 	for k, check := range stats.Health.Checks {

--- a/collectors/health_test.go
+++ b/collectors/health_test.go
@@ -360,6 +360,14 @@ $ sudo ceph -s
 				"count": 10,
 				"state_name": "undersized+degraded+peered"
 			},
+		    {
+				"state_name": "active+remapped+backfilling",
+				"count": 6
+		    },
+		    {
+				"state_name": "active+remapped+backfill_wait",
+				"count": 7
+		    },
 			{
 				"count": 20,
 				"state_name": "activating+undersized+degraded"
@@ -397,6 +405,8 @@ $ sudo ceph -s
 	}	
 }`,
 			regexes: []*regexp.Regexp{
+				regexp.MustCompile(`backfill_wait_pgs{cluster="ceph"} 7`),
+				regexp.MustCompile(`backfilling_pgs{cluster="ceph"} 6`),
 				regexp.MustCompile(`degraded_pgs{cluster="ceph"} 40`),
 				regexp.MustCompile(`unclean_pgs{cluster="ceph"} 30`),
 				regexp.MustCompile(`undersized_pgs{cluster="ceph"} 40`),

--- a/collectors/health_test.go
+++ b/collectors/health_test.go
@@ -40,44 +40,10 @@ func TestClusterHealthCollector(t *testing.T) {
 			"num_remapped_pgs": 0
 		}
 	},
-	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "5 pgs degraded"}]}
-}`,
-			regexes: []*regexp.Regexp{
-				regexp.MustCompile(`degraded_pgs{cluster="ceph"} 5`),
-			},
-		},
-		{
-			input: `
-{
-	"osdmap": {
-		"osdmap": {
-			"num_osds": 0,
-			"num_up_osds": 0,
-			"num_in_osds": 0,
-			"num_remapped_pgs": 0
-		}
-	},
 	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "15 pgs stuck degraded"}]}
 }`,
 			regexes: []*regexp.Regexp{
 				regexp.MustCompile(`stuck_degraded_pgs{cluster="ceph"} 15`),
-			},
-		},
-		{
-			input: `
-{
-	"osdmap": {
-		"osdmap": {
-			"num_osds": 0,
-			"num_up_osds": 0,
-			"num_in_osds": 0,
-			"num_remapped_pgs": 0
-		}
-	},
-	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "6 pgs unclean"}]}
-}`,
-			regexes: []*regexp.Regexp{
-				regexp.MustCompile(`unclean_pgs{cluster="ceph"} 6`),
 			},
 		},
 		{
@@ -108,23 +74,6 @@ func TestClusterHealthCollector(t *testing.T) {
 			"num_remapped_pgs": 0
 		}
 	},
-	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "7 pgs undersized"}]}
-}`,
-			regexes: []*regexp.Regexp{
-				regexp.MustCompile(`undersized_pgs{cluster="ceph"} 7`),
-			},
-		},
-		{
-			input: `
-{
-	"osdmap": {
-		"osdmap": {
-			"num_osds": 0,
-			"num_up_osds": 0,
-			"num_in_osds": 0,
-			"num_remapped_pgs": 0
-		}
-	},
 	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "17 pgs stuck undersized"}]}
 }`,
 			regexes: []*regexp.Regexp{
@@ -142,61 +91,10 @@ func TestClusterHealthCollector(t *testing.T) {
 			"num_remapped_pgs": 0
 		}
 	},
-	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "8 pgs stale"}]}
-}`,
-			regexes: []*regexp.Regexp{
-				regexp.MustCompile(`stale_pgs{cluster="ceph"} 8`),
-			},
-		},
-		{
-			input: `
-{
-	"osdmap": {
-		"osdmap": {
-			"num_osds": 0,
-			"num_up_osds": 0,
-			"num_in_osds": 0,
-			"num_remapped_pgs": 0
-		}
-	},
 	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "18 pgs stuck stale"}]}
 }`,
 			regexes: []*regexp.Regexp{
 				regexp.MustCompile(`stuck_stale_pgs{cluster="ceph"} 18`),
-			},
-		},
-		{
-			input: `
-{
-	"osdmap": {
-		"osdmap": {
-			"num_osds": 0,
-			"num_up_osds": 0,
-			"num_in_osds": 0,
-			"num_remapped_pgs": 0
-		}
-	},
-	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "recovery 10/20 objects degraded"}]}
-}`,
-			regexes: []*regexp.Regexp{
-				regexp.MustCompile(`degraded_objects{cluster="ceph"} 10`),
-			},
-		},
-		{
-			input: `
-{
-	"osdmap": {
-		"osdmap": {
-			"num_osds": 0,
-			"num_up_osds": 0,
-			"num_in_osds": 0,
-			"num_remapped_pgs": 0
-		}
-	},
-	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "recovery 20/40 objects misplaced"}]}
-}`,
-			regexes: []*regexp.Regexp{
-				regexp.MustCompile(`misplaced_objects{cluster="ceph"} 20`),
 			},
 		},
 		{


### PR DESCRIPTION
Switch to using the json output from `ceph status --format=json` for degraded and misplaced object counts. Also cleaned up a bunch of old style metrics which were made redundant by json. Finally, added support for `backfilling` and `backfill_wait` counts. 