### PR TITLE
health: capture slow request per osd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ env:
   - DOCKER_TAG=$TRAVIS_TAG
 
 before_install:
+  - wget -q -O- 'https://download.ceph.com/keys/release.asc' | sudo apt-key add -
+  - echo deb https://download.ceph.com/debian-luminous/ $(lsb_release -sc) main | sudo tee /etc/apt/sources.list.d/ceph.list
   - sudo apt-get update
   - sudo apt-get install -y librados-dev librbd-dev
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,10 @@ ENV PATH $GOROOT/bin:$PATH
 ENV APPLOC $GOPATH/src/github.com/digitalocean/ceph_exporter
 
 RUN apt-get update && \
-    apt-get install -y apt-transport-https build-essential git curl
+    apt-get install -y apt-transport-https build-essential git curl wget
 
-RUN echo "deb https://download.ceph.com/debian-jewel xenial main" >> /etc/apt/sources.list
+RUN wget -q -O- 'https://download.ceph.com/keys/release.asc' | apt-key add -
+RUN echo "deb https://download.ceph.com/debian-luminous xenial main" >> /etc/apt/sources.list
 
 RUN apt-get update && \
     apt-get install -y --force-yes librados-dev librbd-dev
@@ -28,8 +29,9 @@ FROM ubuntu:16.04
 MAINTAINER Vaibhav Bhembre <vaibhav@digitalocean.com>
 
 RUN apt-get update && \
-    apt-get install -y apt-transport-https curl && \
-    echo "deb https://download.ceph.com/debian-jewel xenial main" >> /etc/apt/sources.list && \
+    apt-get install -y apt-transport-https curl wget
+RUN wget -q -O- 'https://download.ceph.com/keys/release.asc' | apt-key add -
+RUN echo "deb https://download.ceph.com/debian-luminous xenial main" >> /etc/apt/sources.list && \
     apt-get update && \
     apt-get install -y --force-yes librados2 librbd1 && \
     rm -rf /var/lib/apt/lists/*

--- a/collectors/health_test.go
+++ b/collectors/health_test.go
@@ -441,6 +441,88 @@ $ sudo ceph -s
 		{
 			input: `
 {
+  	"checks": {
+    	"REQUEST_SLOW": {
+			"severity": "HEALTH_WARN",
+			"summary": {
+				"message": "286 slow requests are blocked > 32 sec"
+			},
+			"detail": [
+				{
+					"message": "102 ops are blocked > 524.288 sec"
+				},
+				{
+					"message": "84 ops are blocked > 262.144 sec"
+				},
+				{
+					"message": "53 ops are blocked > 131.072 sec"
+				},
+				{
+					"message": "33 ops are blocked > 65.536 sec"
+				},
+				{
+					"message": "14 ops are blocked > 32.768 sec"
+				},
+				{
+					"message": "osds 363,463 have blocked requests > 32.768 sec"
+				},
+				{
+					"message": "osd.349 has blocked requests > 524.288 sec"
+				}
+			]
+      	}
+    }
+}`,
+			regexes: []*regexp.Regexp{
+				regexp.MustCompile(`slow_requests_osd{cluster="ceph",osd="363"} 14`),
+				regexp.MustCompile(`slow_requests_osd{cluster="ceph",osd="463"} 14`),
+				regexp.MustCompile(`slow_requests_osd{cluster="ceph",osd="349"} 272`),
+			},
+		},
+		{
+			input: `
+{
+  	"checks": {
+    	"REQUEST_SLOW": {
+			"severity": "HEALTH_WARN",
+			"summary": {
+				"message": "286 slow requests are blocked > 32 sec"
+			},
+			"detail": [
+				{
+					"message": "102 ops are blocked > 524.288 sec"
+				},
+				{
+					"message": "84 ops are blocked > 262.144 sec"
+				},
+				{
+					"message": "53 ops are blocked > 131.072 sec"
+				},
+				{
+					"message": "33 ops are blocked > 65.536 sec"
+				},
+				{
+					"message": "14 ops are blocked > 32.768 sec"
+				},
+				{
+					"message": "osds 363,463 have blocked requests > 131.072 sec"
+				},
+				{
+					"message": "osd.349 has blocked requests > 524.288 sec"
+				}
+			]
+      	}
+    }
+}`,
+			regexes: []*regexp.Regexp{
+				regexp.MustCompile(`slow_requests_osd{cluster="ceph",osd="363"} 100`),
+				regexp.MustCompile(`slow_requests_osd{cluster="ceph",osd="463"} 100`),
+				regexp.MustCompile(`slow_requests_osd{cluster="ceph",osd="349"} 186`),
+			},
+		},
+		{
+			input: `
+{
 	"pgmap": {
 		"write_op_per_sec": 500,
 		"read_op_per_sec": 1000,


### PR DESCRIPTION
This adds in functionality to track slow requests per OSD. If slow requests exist on multiple OSD they will show up too. Currently Ceph displays no breakdown if multiple OSDs exhibit slow request in same time interval, which complicates our efforts to find accurate value. We assume the worst case in such a situation and count max no. of slow requests for each such OSD. This change keeps the older `slow_requests` stat for backwards compatibility since we don't want the stat to simply vanish if people have built tooling or alerting around it. 