### PR TITLE
Ssobolewski/run rgw stats in background

### DIFF
--- a/collectors/rgw.go
+++ b/collectors/rgw.go
@@ -14,6 +14,12 @@ const rgwGCTimeFormat = "2006-01-02 15:04:05"
 const radosgwAdminPath = "/usr/bin/radosgw-admin"
 const backgroundCollectInterval = time.Duration(5 * time.Minute)
 
+const (
+	RGWModeDisabled   = 0
+	RGWModeForeground = 1
+	RGWModeBackground = 2
+)
+
 type rgwTaskGC struct {
 	Tag     string `json:"tag"`
 	Time    string `json:"time"`

--- a/collectors/rgw.go
+++ b/collectors/rgw.go
@@ -12,6 +12,7 @@ import (
 
 const rgwGCTimeFormat = "2006-01-02 15:04:05"
 const radosgwAdminPath = "/usr/bin/radosgw-admin"
+const backgroundCollectInterval = time.Duration(5 * time.Minute)
 
 type rgwTaskGC struct {
 	Tag     string `json:"tag"`
@@ -139,7 +140,7 @@ func (r *RGWCollector) backgroundCollect() error {
 		if err != nil {
 			log.Println("Failed to collect RGW GC stats", err)
 		}
-		time.Sleep(time.Minute * 5)
+		time.Sleep(backgroundCollectInterval)
 	}
 }
 

--- a/collectors/rgw_test.go
+++ b/collectors/rgw_test.go
@@ -114,7 +114,7 @@ func TestRGWCollector(t *testing.T) {
 		},
 	} {
 		func() {
-			collector := NewRGWCollector("ceph", "")
+			collector := NewRGWCollector("ceph", "", false) // run in foreground for testing
 			collector.getRGWGCTaskList = func(cluster string) ([]byte, error) {
 				if tt.input != nil {
 					return tt.input, nil

--- a/exporter.go
+++ b/exporter.go
@@ -79,7 +79,7 @@ var _ prometheus.Collector = &CephExporter{}
 // NewCephExporter creates an instance to CephExporter and returns a reference
 // to it. We can choose to enable a collector to extract stats out of by adding
 // it to the list of collectors.
-func NewCephExporter(conn *rados.Conn, cluster string, config string, withRGW bool) *CephExporter {
+func NewCephExporter(conn *rados.Conn, cluster string, config string, rgwMode int) *CephExporter {
 	c := &CephExporter{
 		collectors: []prometheus.Collector{
 			collectors.NewClusterUsageCollector(conn, cluster),
@@ -90,10 +90,22 @@ func NewCephExporter(conn *rados.Conn, cluster string, config string, withRGW bo
 		},
 	}
 
-	if withRGW {
+	switch rgwMode {
+	case collectors.RGWModeForeground:
+		c.collectors = append(c.collectors,
+			collectors.NewRGWCollector(cluster, config, false),
+		)
+
+	case collectors.RGWModeBackground:
 		c.collectors = append(c.collectors,
 			collectors.NewRGWCollector(cluster, config, true),
 		)
+
+	case collectors.RGWModeDisabled:
+		// nothing to do
+
+	default:
+		log.Printf("RGW Collector Disabled do to invalid mode (%d)\n", rgwMode)
 	}
 
 	return c
@@ -126,7 +138,7 @@ func main() {
 		cephConfig  = flag.String("ceph.config", "", "path to ceph config file")
 		cephUser    = flag.String("ceph.user", "admin", "Ceph user to connect to cluster.")
 
-		withRGW = flag.Bool("with-rgw", false, "Enable collection of stats from RGW")
+		rgwMode = flag.Int("rgw.mode", 0, "Enable collection of stats from RGW (0:disabled 1:enabled 2:background)")
 
 		exporterConfig = flag.String("exporter.config", "/etc/ceph/exporter.yml", "Path to ceph exporter config.")
 	)
@@ -158,7 +170,7 @@ func main() {
 			defer conn.Shutdown()
 
 			log.Printf("Starting ceph exporter for cluster: %s", cluster.ClusterLabel)
-			err = prometheus.Register(NewCephExporter(conn, cluster.ClusterLabel, cluster.ConfigFile, *withRGW))
+			err = prometheus.Register(NewCephExporter(conn, cluster.ClusterLabel, cluster.ConfigFile, *rgwMode))
 			if err != nil {
 				log.Fatalf("cannot export cluster: %s error: %v", cluster.ClusterLabel, err)
 			}
@@ -183,7 +195,7 @@ func main() {
 		}
 		defer conn.Shutdown()
 
-		prometheus.MustRegister(NewCephExporter(conn, defaultCephClusterLabel, defaultCephConfigPath, *withRGW))
+		prometheus.MustRegister(NewCephExporter(conn, defaultCephClusterLabel, defaultCephConfigPath, *rgwMode))
 	}
 
 	http.Handle(*metricsPath, promhttp.Handler())

--- a/exporter.go
+++ b/exporter.go
@@ -92,7 +92,7 @@ func NewCephExporter(conn *rados.Conn, cluster string, config string, withRGW bo
 
 	if withRGW {
 		c.collectors = append(c.collectors,
-			collectors.NewRGWCollector(cluster, config),
+			collectors.NewRGWCollector(cluster, config, true),
 		)
 	}
 


### PR DESCRIPTION
When the RGW gc backlog is large ( > 1M ) it can take longer(~30sec) to fetch it then a typical prom scrape timeout.   So instead run this scan in the background every 5 min.