### PR TITLE
health: fix degraded/misplaced object count

### DIFF
--- a/collectors/health_test.go
+++ b/collectors/health_test.go
@@ -442,6 +442,42 @@ $ sudo ceph -s
 		{
 			input: `
 {
+  "health": {
+    "checks": {
+      "PG_DEGRADED": {
+        "severity": "HEALTH_WARN",
+        "summary": {
+          "message": "Degraded data redundancy: 154443937/17497658377 objects degraded (0.883%), 4886 pgs unclean, 4317 pgs degraded, 516 pgs undersized"
+        }
+      }
+    }
+  }
+}`,
+			regexes: []*regexp.Regexp{
+				regexp.MustCompile(`degraded_objects{cluster="ceph"} 1.54443937e\+08`),
+			},
+		},
+		{
+			input: `
+{
+  "health": {
+    "checks": {
+      "OBJECT_MISPLACED": {
+        "severity": "HEALTH_WARN",
+        "summary": {
+          "message": "431295341/17497658377 objects misplaced (2.465%)"
+        }
+      }
+    }
+  }
+}`,
+			regexes: []*regexp.Regexp{
+				regexp.MustCompile(`misplaced_objects{cluster="ceph"} 4.31295341e\+08`),
+			},
+		},
+		{
+			input: `
+{
   	"checks": {
 		"REQUEST_STUCK": {
 			"detail": [


### PR DESCRIPTION
The degraded and misplaced object stats were showing incorrectly as 0 because they were not being picked up properly from new checks that went into luminous. This attempts at fixing that issue.

r: @robbat2 @ralfonso 