### PR TITLE
exporter: register pool info collector

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -84,6 +84,7 @@ func NewCephExporter(conn *rados.Conn, cluster string, config string, rgwMode in
 		collectors: []prometheus.Collector{
 			collectors.NewClusterUsageCollector(conn, cluster),
 			collectors.NewPoolUsageCollector(conn, cluster),
+			collectors.NewPoolInfoCollector(conn, cluster),
 			collectors.NewClusterHealthCollector(conn, cluster),
 			collectors.NewMonitorCollector(conn, cluster),
 			collectors.NewOSDCollector(conn, cluster),


### PR DESCRIPTION
Register the `PoolInfoCollector` with generic Ceph exporter runs.

r: @alram 