### PR TITLE
collector/health: add stuck request metric

### DIFF
--- a/collectors/health_test.go
+++ b/collectors/health_test.go
@@ -444,6 +444,24 @@ $ sudo ceph -s
 {
   "health": {
     "checks": {
+      "REQUEST_STUCK": {
+        "severity": "HEALTH_ERR",
+        "summary": {
+          "message": "125 stuck requests are blocked > 4194.3 sec"
+        }
+      }
+    }
+  }
+}`,
+			regexes: []*regexp.Regexp{
+				regexp.MustCompile(`stuck_requests{cluster="ceph"} 125`),
+			},
+		},
+		{
+			input: `
+{
+  "health": {
+    "checks": {
       "PG_DEGRADED": {
         "severity": "HEALTH_WARN",
         "summary": {


### PR DESCRIPTION
This change adds "stuck_requests" metric to ceph exporter so we can track those separately to slow requests.

r: @alram 