### PR TITLE
Exporter: Type errors

### DIFF
--- a/collectors/health.go
+++ b/collectors/health.go
@@ -900,6 +900,8 @@ func (c *ClusterHealthCollector) collect(ch chan<- prometheus.Metric) error {
 		osdmapFlagsRegex          = regexp.MustCompile(`([^ ]+) flag\(s\) set`)
 	)
 
+	var mapEmpty = len(c.healthChecksMap) == 0
+
 	for _, s := range stats.Health.Summary {
 		matched := degradedRegex.FindStringSubmatch(s.Summary)
 		if len(matched) == 2 {
@@ -1090,7 +1092,7 @@ func (c *ClusterHealthCollector) collect(ch chan<- prometheus.Metric) error {
 				}
 			}
 		}
-		if c.healthChecksMap != nil {
+		if !mapEmpty {
 			if val, present := c.healthChecksMap[k]; present {
 				c.HealthStatusInterpreter.Set(float64(val))
 			}

--- a/exporter.go
+++ b/exporter.go
@@ -172,7 +172,7 @@ func main() {
 			defer conn.Shutdown()
 
 			log.Printf("Starting ceph exporter for cluster: %s", cluster.ClusterLabel)
-			err = prometheus.Register(NewCephExporter(conn, cluster.ClusterLabel, cluster.ConfigFile, *rgwMode, cfg.Warnings))
+			err = prometheus.Register(NewCephExporter(conn, cluster.ClusterLabel, cluster.ConfigFile, *rgwMode, *cfg.Warnings))
 			if err != nil {
 				log.Fatalf("cannot export cluster: %s error: %v", cluster.ClusterLabel, err)
 			}
@@ -197,7 +197,7 @@ func main() {
 		}
 		defer conn.Shutdown()
 
-		prometheus.MustRegister(NewCephExporter(conn, defaultCephClusterLabel, defaultCephConfigPath, *rgwMode, nil))
+		prometheus.MustRegister(NewCephExporter(conn, defaultCephClusterLabel, defaultCephConfigPath, *rgwMode, WarningCategorization{CheckNames: map[string]int{}}))
 	}
 
 	http.Handle(*metricsPath, promhttp.Handler())


### PR DESCRIPTION
Fixing failed builds due to errors in the struct being passed for health warning map.