### PR TITLE
Support OSD Latency for Nautilus release

### DIFF
--- a/collectors/osd.go
+++ b/collectors/osd.go
@@ -385,6 +385,10 @@ type cephPerfStat struct {
 	} `json:"osd_perf_infos"`
 }
 
+type cephOSDPerfStat struct {
+	cephPerfStat `json:"osdstats"`
+}
+
 type cephOSDDump struct {
 	OSDs []struct {
 		OSD   json.Number `json:"osd"`
@@ -534,7 +538,7 @@ func (o *OSDCollector) collectOSDPerf() error {
 		return err
 	}
 
-	osdPerf := &cephPerfStat{}
+	osdPerf := &CephOSDPerfStat{}
 	if err := json.Unmarshal(buf, osdPerf); err != nil {
 		return err
 	}

--- a/collectors/osd.go
+++ b/collectors/osd.go
@@ -538,7 +538,7 @@ func (o *OSDCollector) collectOSDPerf() error {
 		return err
 	}
 
-	osdPerf := &CephOSDPerfStat{}
+	osdPerf := &cephOSDPerfStat{}
 	if err := json.Unmarshal(buf, osdPerf); err != nil {
 		return err
 	}

--- a/collectors/osd_test.go
+++ b/collectors/osd_test.go
@@ -161,43 +161,45 @@ func TestOSDCollector(t *testing.T) {
 		{
 			input: `
 {
-    "osd_perf_infos": [
-        {
-            "id": 4,
-            "perf_stats": {
-                "commit_latency_ms": 0,
-                "apply_latency_ms": 0
-            }
-        },
-        {
-            "id": 3,
-            "perf_stats": {
-                "commit_latency_ms": 1,
-                "apply_latency_ms": 64
-            }
-        },
-        {
-            "id": 2,
-            "perf_stats": {
-                "commit_latency_ms": 2,
-                "apply_latency_ms": 79
-            }
-        },
-        {
-            "id": 1,
-            "perf_stats": {
-                "commit_latency_ms": 2,
-                "apply_latency_ms": 39
-            }
-        },
-        {
-            "id": 0,
-            "perf_stats": {
-                "commit_latency_ms": 2,
-                "apply_latency_ms": 31
-            }
-        }
-    ]
+	"osdstats": {
+		"osd_perf_infos": [
+			{
+				"id": 4,
+				"perf_stats": {
+					"commit_latency_ms": 0,
+					"apply_latency_ms": 0
+				}
+			},
+			{
+				"id": 3,
+				"perf_stats": {
+					"commit_latency_ms": 1,
+					"apply_latency_ms": 64
+				}
+			},
+			{
+				"id": 2,
+				"perf_stats": {
+					"commit_latency_ms": 2,
+					"apply_latency_ms": 79
+				}
+			},
+			{
+				"id": 1,
+				"perf_stats": {
+					"commit_latency_ms": 2,
+					"apply_latency_ms": 39
+				}
+			},
+			{
+				"id": 0,
+				"perf_stats": {
+					"commit_latency_ms": 2,
+					"apply_latency_ms": 31
+				}
+			}
+		]
+	}
 }`,
 			regexes: []*regexp.Regexp{
 				regexp.MustCompile(`ceph_osd_perf_commit_latency_seconds{cluster="ceph",osd="osd.0"} 0.002`),


### PR DESCRIPTION
With Ceph Nautilus release, The output of this command `ceph osd perf --format json` is different with luminous/mimic.

WIth this PR, I have changed the struct to unmarshal the data. Please create a new branch `nautilus`. 

Thank you.