### PR TITLE
osd: update ceph_pg_objects_recovered_total in every scrape

### DIFF
--- a/collectors/osd_test.go
+++ b/collectors/osd_test.go
@@ -611,20 +611,17 @@ func TestOSDCollector(t *testing.T) {
 
 			var buf []byte
 
-			// scrape at least twice to have the metrics for number of objects
-			// recovered available
-			for i := 0; i < 2; i++ {
-				resp, err := http.Get(server.URL)
-				if err != nil {
-					t.Fatalf("unexpected failed response from prometheus: %s", err)
-				}
-				defer resp.Body.Close()
-
-				buf, err = ioutil.ReadAll(resp.Body)
-				if err != nil {
-					t.Fatalf("failed reading server response: %s", err)
-				}
+			resp, err := http.Get(server.URL)
+			if err != nil {
+				t.Fatalf("unexpected failed response from prometheus: %s", err)
 			}
+			defer resp.Body.Close()
+
+			buf, err = ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("failed reading server response: %s", err)
+			}
+
 			for _, re := range tt.regexes {
 				if !re.Match(buf) {
 					t.Errorf("failed matching: %q", re)


### PR DESCRIPTION
It is found that `ceph_pg_objects_recovered_total` does not show up unless there is a PG in recovering state. In order to make it available even if no PG is recovering, update it for every scrape.

