### PR TITLE
osd: add a counter for number of objects backfilled on each OSD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 dist: trusty
 
 go:
-  - 1.9.2
+  - 1.13
 
 env:
   - DOCKER_TAG=$TRAVIS_TAG

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
 
 RUN \
   mkdir -p /goroot && \
-  curl https://storage.googleapis.com/golang/go1.9.2.linux-amd64.tar.gz | tar xvzf - -C /goroot --strip-components=1
+  curl https://storage.googleapis.com/golang/go1.13.linux-amd64.tar.gz | tar xvzf - -C /goroot --strip-components=1
 
 ADD . $APPLOC
 WORKDIR $APPLOC

--- a/Makefile.COMMON
+++ b/Makefile.COMMON
@@ -44,7 +44,7 @@ SRC    ?= $(shell find . -type f -name "*.go" ! -path "./.build/*")
 GOOS   ?= $(shell uname | tr A-Z a-z)
 GOARCH ?= $(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m)))
 
-GO_VERSION ?= 1.5.3
+GO_VERSION ?= 1.13
 
 # Check for the correct version of go in the path. If we find it, use it.
 # Otherwise, prepare to build go locally.

--- a/collectors/conn.go
+++ b/collectors/conn.go
@@ -43,8 +43,9 @@ var _ Conn = &rados.Conn{}
 // we can deprecate output, because cmdOut is able to hold the outputs we desire
 // for multiple commands for "go test".
 type NoopConn struct {
-	output string // deprecated
-	cmdOut map[string]string
+	output    string // deprecated
+	cmdOut    []map[string]string
+	iteration int
 }
 
 // The stub we use for testing should also satisfy the interface properties.
@@ -54,17 +55,22 @@ var _ Conn = &NoopConn{}
 // at the end of the command we issue to Ceph is fixed and should be specified
 // in the only input parameter.
 func NewNoopConn(output string) *NoopConn {
-	return &NoopConn{
-		output: output,
-		cmdOut: make(map[string]string),
-	}
+	return &NoopConn{output: output}
 }
 
 // NewNoopConnWithCmdOut returns an instance of *NoopConn. The string that we
 // want output at the end of the command we issue to Ceph can be various and
 // should be specified by the map in the only input parameter.
-func NewNoopConnWithCmdOut(cmdOut map[string]string) *NoopConn {
-	return &NoopConn{cmdOut: cmdOut}
+func NewNoopConnWithCmdOut(cmdOut []map[string]string) *NoopConn {
+	return &NoopConn{
+		cmdOut:    cmdOut,
+		iteration: 0,
+	}
+}
+
+// IncIteration increments iteration by 1.
+func (n *NoopConn) IncIteration() {
+	n.iteration++
 }
 
 // ReadDefaultConfigFile does not need to return an error. It satisfies
@@ -107,7 +113,7 @@ func (n *NoopConn) MonCommand(args []byte) ([]byte, string, error) {
 
 		switch dc[0] {
 		case "pgs_brief":
-			return []byte(n.cmdOut["ceph pg dump pgs_brief"]), "", nil
+			return []byte(n.cmdOut[n.iteration]["ceph pg dump pgs_brief"]), "", nil
 		}
 
 	case "osd tree":
@@ -123,17 +129,17 @@ func (n *NoopConn) MonCommand(args []byte) ([]byte, string, error) {
 
 		switch st[0] {
 		case "down":
-			return []byte(n.cmdOut["ceph osd tree down"]), "", nil
+			return []byte(n.cmdOut[n.iteration]["ceph osd tree down"]), "", nil
 		}
 
 	case "osd df":
-		return []byte(n.cmdOut["ceph osd df"]), "", nil
+		return []byte(n.cmdOut[n.iteration]["ceph osd df"]), "", nil
 
 	case "osd perf":
-		return []byte(n.cmdOut["ceph osd perf"]), "", nil
+		return []byte(n.cmdOut[n.iteration]["ceph osd perf"]), "", nil
 
 	case "osd dump":
-		return []byte(n.cmdOut["ceph osd dump"]), "", nil
+		return []byte(n.cmdOut[n.iteration]["ceph osd dump"]), "", nil
 	}
 
 	return []byte(n.output), "", nil
@@ -152,7 +158,7 @@ func (n *NoopConn) PGCommand(pgid, args []byte) ([]byte, string, error) {
 	// Intercept and mock the output
 	switch prefix := cmd["prefix"]; prefix {
 	case "query":
-		return []byte(n.cmdOut[fmt.Sprintf("ceph tell %s query", string(pgid))]), "", nil
+		return []byte(n.cmdOut[n.iteration][fmt.Sprintf("ceph tell %s query", string(pgid))]), "", nil
 	}
 
 	return []byte(n.output), "", nil

--- a/collectors/osd.go
+++ b/collectors/osd.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"math"
 	"regexp"
 	"strconv"
 
@@ -820,11 +821,11 @@ func (o *OSDCollector) collectPGRecoveryState(ch chan<- prometheus.Metric) error
 		// We need previous PG state in order to update the metric when a PG has
 		// completed recovery or backfill. Or it could be an empty string if
 		// unknown.
-		prevPGState := o.pgStateCache[pg.PGID]
+		prevPGState, prevPGStateFound := o.pgStateCache[pg.PGID]
 		prevNumObjectsRecovered := o.pgObjectsRecoveredCache[pg.PGID]
 		prevBackfillTargets := o.pgBackfillTargetsCache[pg.PGID]
 
-		if prevPGState == "" || strings.Contains(prevPGState, "recovering") || strings.Contains(pg.State, "recovering") ||
+		if !prevPGStateFound || strings.Contains(prevPGState, "recovering") || strings.Contains(pg.State, "recovering") ||
 			strings.Contains(prevPGState, "backfilling") || strings.Contains(pg.State, "backfilling") {
 			query, err := o.performPGQuery(pg.PGID)
 			if err != nil {
@@ -845,7 +846,9 @@ func (o *OSDCollector) collectPGRecoveryState(ch chan<- prometheus.Metric) error
 			}
 
 			// Average out the total number of objects backfilled to each OSD
-			eachOSDIncrease := float64(o.pgObjectsRecoveredCache[pg.PGID]-prevNumObjectsRecovered) / float64(len(prevBackfillTargets))
+			// The average number rounds to the nearest integer, rounding half
+			// away from zero.
+			eachOSDIncrease := math.Round(float64(o.pgObjectsRecoveredCache[pg.PGID]-prevNumObjectsRecovered) / float64(len(prevBackfillTargets)))
 
 			for osdID := range prevBackfillTargets {
 				// It is possible that osdID has gone from the backfill_targets

--- a/collectors/osd.go
+++ b/collectors/osd.go
@@ -29,16 +29,23 @@ const (
 type OSDCollector struct {
 	conn Conn
 
-	// initialCollect flags if it is the first time for this OSDCollector to
-	// collect metrics.
-	initialCollect bool
-
 	// osdScrubCache holds the cache of previous PG scrubs
 	osdScrubCache map[int]int
+
+	// osdObjectsBackfilledCache holds the cache of previous increase in number
+	// of objects backfilled of all OSDs
+	osdObjectsBackfilledCache map[int64]int64
+
+	// pgStateCache holds the cache of previous states of all PGs
+	pgStateCache map[string]string
 
 	// pgObjectsRecoveredCache holds the cache of previous number of objects
 	// recovered of all PGs
 	pgObjectsRecoveredCache map[string]int64
+
+	// pgBackfillTargetsCache holds the cache of previous backfill targets OSDs
+	// of all PGs
+	pgBackfillTargetsCache map[string]map[int64]int64
 
 	// pgDumpBrief holds the content of PG dump brief
 	pgDumpBrief cephPGDumpBrief
@@ -115,6 +122,9 @@ type OSDCollector struct {
 
 	// PGObjectsRecoveredDesc displays total number of objects recovered in a PG
 	PGObjectsRecoveredDesc *prometheus.Desc
+
+	// OSDObjectsBackfilled displays average number of objects backfilled in an OSD
+	OSDObjectsBackfilled *prometheus.CounterVec
 }
 
 // This ensures OSDCollector implements interface prometheus.Collector.
@@ -127,10 +137,13 @@ func NewOSDCollector(conn Conn, cluster string) *OSDCollector {
 	labels["cluster"] = cluster
 
 	return &OSDCollector{
-		conn:                    conn,
-		initialCollect:          true,
-		osdScrubCache:           make(map[int]int),
-		pgObjectsRecoveredCache: make(map[string]int64),
+		conn: conn,
+
+		osdScrubCache:             make(map[int]int),
+		osdObjectsBackfilledCache: make(map[int64]int64),
+		pgStateCache:              make(map[string]string),
+		pgObjectsRecoveredCache:   make(map[string]int64),
+		pgBackfillTargetsCache:    make(map[string]map[int64]int64),
 
 		CrushWeight: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
@@ -347,6 +360,16 @@ func NewOSDCollector(conn Conn, cluster string) *OSDCollector {
 			[]string{"pgid"},
 			labels,
 		),
+
+		OSDObjectsBackfilled: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace:   cephNamespace,
+				Name:        "osd_objects_backfilled",
+				Help:        "Average number of objects backfilled in an OSD",
+				ConstLabels: labels,
+			},
+			[]string{"pgid", "osd"},
+		),
 	}
 }
 
@@ -372,6 +395,7 @@ func (o *OSDCollector) collectorList() []prometheus.Collector {
 		o.OSDFull,
 		o.OSDNearFull,
 		o.OSDBackfillFull,
+		o.OSDObjectsBackfilled,
 	}
 }
 
@@ -463,25 +487,27 @@ func (c cephPGQuery) backfillTargets() map[int64]int64 {
 	targets := make(map[int64]int64)
 
 	for _, state := range c.RecoveryState {
-		if state.RecoverProgress != nil {
-			for _, osd := range state.RecoverProgress.BackfillTargets {
-				m := osdRegExp.FindStringSubmatch(osd)
-				if m == nil {
-					continue
-				}
+		if state.RecoverProgress == nil {
+			continue
+		}
 
-				osdID, err := strconv.ParseInt(m[1], 10, 32)
-				if err != nil {
-					continue
-				}
-
-				shard, err := strconv.ParseInt(m[2], 10, 32)
-				if err != nil {
-					continue
-				}
-
-				targets[osdID] = shard
+		for _, osd := range state.RecoverProgress.BackfillTargets {
+			m := osdRegExp.FindStringSubmatch(osd)
+			if m == nil {
+				continue
 			}
+
+			osdID, err := strconv.ParseInt(m[1], 10, 64)
+			if err != nil {
+				continue
+			}
+
+			shard, err := strconv.ParseInt(m[2], 10, 64)
+			if err != nil {
+				continue
+			}
+
+			targets[osdID] = shard
 		}
 	}
 
@@ -790,21 +816,51 @@ func (o *OSDCollector) collectOSDScrubState(ch chan<- prometheus.Metric) error {
 
 func (o *OSDCollector) collectPGRecoveryState(ch chan<- prometheus.Metric) error {
 	for _, pg := range o.pgDumpBrief {
-		if o.initialCollect || strings.Contains(pg.State, "recovering") {
+
+		// We need previous PG state in order to update the metric when a PG has
+		// completed recovery or backfill. Or it could be an empty string if
+		// unknown.
+		prevPGState := o.pgStateCache[pg.PGID]
+		prevNumObjectsRecovered := o.pgObjectsRecoveredCache[pg.PGID]
+		prevBackfillTargets := o.pgBackfillTargetsCache[pg.PGID]
+
+		if prevPGState == "" || strings.Contains(prevPGState, "recovering") || strings.Contains(pg.State, "recovering") ||
+			strings.Contains(prevPGState, "backfilling") || strings.Contains(pg.State, "backfilling") {
 			query, err := o.performPGQuery(pg.PGID)
 			if err != nil {
 				continue
 			}
 
+			o.pgStateCache[pg.PGID] = pg.State
 			o.pgObjectsRecoveredCache[pg.PGID] = query.Info.Stats.StatSum.NumObjectsRecovered
+			o.pgBackfillTargetsCache[pg.PGID] = query.backfillTargets()
+
+			// There is no previous backfill_targets, and we have just cached
+			// it. Wait for the next time so that we can know the increased
+			// number of objects backfilled for this entire PG and compute the
+			// average increased number of objects backfilled for each OSD in
+			// the backfill_targets.
+			if prevBackfillTargets == nil || len(prevBackfillTargets) == 0 {
+				continue
+			}
+
+			// Average out the total number of objects backfilled to each OSD
+			eachOSDIncrease := float64(o.pgObjectsRecoveredCache[pg.PGID]-prevNumObjectsRecovered) / float64(len(prevBackfillTargets))
+
+			for osdID := range prevBackfillTargets {
+				// It is possible that osdID has gone from the backfill_targets
+				// this time if backfill has completed on it. In this case we
+				// still count the increase to this OSD.
+				o.OSDObjectsBackfilled.WithLabelValues(pg.PGID, fmt.Sprintf(osdLabelFormat, osdID)).Add(eachOSDIncrease)
+			}
 		}
 	}
 
-	for pgid, val := range o.pgObjectsRecoveredCache {
+	for pgid, v := range o.pgObjectsRecoveredCache {
 		ch <- prometheus.MustNewConstMetric(
 			o.PGObjectsRecoveredDesc,
 			prometheus.GaugeValue,
-			float64(val),
+			float64(v),
 			pgid)
 	}
 
@@ -926,10 +982,6 @@ func (o *OSDCollector) Collect(ch chan<- prometheus.Metric) {
 		log.Println("failed collecting OSD tree down metrics:", err)
 	}
 
-	for _, metric := range o.collectorList() {
-		metric.Collect(ch)
-	}
-
 	if err := o.performPGDumpBrief(); err != nil {
 		log.Println("failed performing PG dump brief:", err)
 	}
@@ -942,7 +994,7 @@ func (o *OSDCollector) Collect(ch chan<- prometheus.Metric) {
 		log.Println("failed collecting PG recovery metrics:", err)
 	}
 
-	if o.initialCollect {
-		o.initialCollect = false
+	for _, metric := range o.collectorList() {
+		metric.Collect(ch)
 	}
 }

--- a/collectors/osd_test.go
+++ b/collectors/osd_test.go
@@ -12,12 +12,13 @@ import (
 
 func TestOSDCollector(t *testing.T) {
 	for _, tt := range []struct {
-		cmdOut  map[string]string
-		regexes []*regexp.Regexp
+		cmdOut []map[string]string
+		regExp []*regexp.Regexp
 	}{
 		{
-			cmdOut: map[string]string{
-				"ceph osd df": `
+			cmdOut: []map[string]string{
+				{
+					"ceph osd df": `
 {
   "nodes": [
     {
@@ -107,8 +108,9 @@ func TestOSDCollector(t *testing.T) {
     "dev": 0.017482
   }
 }`,
+				},
 			},
-			regexes: []*regexp.Regexp{
+			regExp: []*regexp.Regexp{
 				regexp.MustCompile(`ceph_osd_crush_weight{cluster="ceph",osd="osd.0"} 0.010391`),
 				regexp.MustCompile(`ceph_osd_crush_weight{cluster="ceph",osd="osd.1"} 0.010391`),
 				regexp.MustCompile(`ceph_osd_crush_weight{cluster="ceph",osd="osd.2"} 0.010391`),
@@ -161,8 +163,9 @@ func TestOSDCollector(t *testing.T) {
 			},
 		},
 		{
-			cmdOut: map[string]string{
-				"ceph osd perf": `
+			cmdOut: []map[string]string{
+				{
+					"ceph osd perf": `
 {
   "osd_perf_infos": [
     {
@@ -202,8 +205,9 @@ func TestOSDCollector(t *testing.T) {
     }
   ]
 }`,
+				},
 			},
-			regexes: []*regexp.Regexp{
+			regExp: []*regexp.Regexp{
 				regexp.MustCompile(`ceph_osd_perf_commit_latency_seconds{cluster="ceph",osd="osd.0"} 0.002`),
 				regexp.MustCompile(`ceph_osd_perf_commit_latency_seconds{cluster="ceph",osd="osd.1"} 0.002`),
 				regexp.MustCompile(`ceph_osd_perf_commit_latency_seconds{cluster="ceph",osd="osd.2"} 0.002`),
@@ -217,8 +221,9 @@ func TestOSDCollector(t *testing.T) {
 			},
 		},
 		{
-			cmdOut: map[string]string{
-				"ceph osd dump": `
+			cmdOut: []map[string]string{
+				{
+					"ceph osd dump": `
 {
   "osds": [
     {
@@ -269,8 +274,9 @@ func TestOSDCollector(t *testing.T) {
     }
   ]
 }`,
+				},
 			},
-			regexes: []*regexp.Regexp{
+			regExp: []*regexp.Regexp{
 				regexp.MustCompile(`ceph_osd_in{cluster="ceph",osd="osd.0"} 1`),
 				regexp.MustCompile(`ceph_osd_in{cluster="ceph",osd="osd.1"} 1`),
 				regexp.MustCompile(`ceph_osd_in{cluster="ceph",osd="osd.2"} 1`),
@@ -299,8 +305,9 @@ func TestOSDCollector(t *testing.T) {
 			},
 		},
 		{
-			cmdOut: map[string]string{
-				"ceph pg dump pgs_brief": `
+			cmdOut: []map[string]string{
+				{
+					"ceph pg dump pgs_brief": `
 [
   {
     "acting": [
@@ -336,8 +343,9 @@ func TestOSDCollector(t *testing.T) {
     "state": "active+clean+scrubbing+deep"
   }
 ]`,
+				},
 			},
-			regexes: []*regexp.Regexp{
+			regExp: []*regexp.Regexp{
 				regexp.MustCompile(`ceph_osd_scrub_state{cluster="ceph",osd="osd.10"} 1`),
 				regexp.MustCompile(`ceph_osd_scrub_state{cluster="ceph",osd="osd.11"} 1`),
 				regexp.MustCompile(`ceph_osd_scrub_state{cluster="ceph",osd="osd.12"} 1`),
@@ -349,8 +357,9 @@ func TestOSDCollector(t *testing.T) {
 			},
 		},
 		{
-			cmdOut: map[string]string{
-				"ceph osd tree down": `
+			cmdOut: []map[string]string{
+				{
+					"ceph osd tree down": `
 {
   "nodes": [],
   "stray": [
@@ -368,14 +377,16 @@ func TestOSDCollector(t *testing.T) {
     }
   ]
 }`,
+				},
 			},
-			regexes: []*regexp.Regexp{
+			regExp: []*regexp.Regexp{
 				regexp.MustCompile(`ceph_osd_down{cluster="ceph",osd="osd.524",status="destroyed"} 1`),
 			},
 		},
 		{
-			cmdOut: map[string]string{
-				"ceph osd tree down": `
+			cmdOut: []map[string]string{
+				{
+					"ceph osd tree down": `
 {
   "nodes": [],
   "stray": [
@@ -393,14 +404,16 @@ func TestOSDCollector(t *testing.T) {
     }
   ]
 }`,
+				},
 			},
-			regexes: []*regexp.Regexp{
+			regExp: []*regexp.Regexp{
 				regexp.MustCompile(`ceph_osd_down{cluster="ceph",osd="osd.524",status="down"} 1`),
 			},
 		},
 		{
-			cmdOut: map[string]string{
-				"ceph osd tree down": `
+			cmdOut: []map[string]string{
+				{
+					"ceph osd tree down": `
 {
   "nodes": [
     {
@@ -449,14 +462,16 @@ func TestOSDCollector(t *testing.T) {
   ],
   "stray": []
 }`,
+				},
 			},
-			regexes: []*regexp.Regexp{
+			regExp: []*regexp.Regexp{
 				regexp.MustCompile(`ceph_osd_down{cluster="ceph",osd="osd.524",status="destroyed"} 1`),
 			},
 		},
 		{
-			cmdOut: map[string]string{
-				"ceph osd tree down": `
+			cmdOut: []map[string]string{
+				{
+					"ceph osd tree down": `
 {
   "nodes": [
     {
@@ -518,24 +533,28 @@ func TestOSDCollector(t *testing.T) {
     }
   ]
 }`,
+				},
 			},
-			regexes: []*regexp.Regexp{
+			regExp: []*regexp.Regexp{
 				regexp.MustCompile(`ceph_osd_down{cluster="ceph",osd="osd.524",status="destroyed"} 1`),
 				regexp.MustCompile(`ceph_osd_down{cluster="ceph",osd="osd.525",status="down"} 1`),
 			},
 		},
 		{
-			cmdOut: map[string]string{
-				"ceph osd tree down": `
+			cmdOut: []map[string]string{
+				{
+					"ceph osd tree down": `
 {
   "nodes": []}}
 }`,
+				},
 			},
-			regexes: []*regexp.Regexp{},
+			regExp: []*regexp.Regexp{},
 		},
 		{
-			cmdOut: map[string]string{
-				"ceph pg dump pgs_brief": `
+			cmdOut: []map[string]string{
+				{
+					"ceph pg dump pgs_brief": `
 [
   {
     "acting": [
@@ -582,7 +601,7 @@ func TestOSDCollector(t *testing.T) {
     "state": "active+recovering+degraded"
   }
 ]`,
-				"ceph tell 84.1fff query": `
+					"ceph tell 84.1fff query": `
 {
   "state": "active+recovering+degraded",
   "info": {
@@ -593,14 +612,182 @@ func TestOSDCollector(t *testing.T) {
     }
   }
 }`,
+				},
+				{
+					"ceph pg dump pgs_brief": `
+[
+  {
+    "acting": [
+      30,
+      31,
+      32,
+      33
+    ],
+    "acting_primary": 30,
+    "pgid": "84.1fff",
+    "state": "active+clean"
+  }
+]`,
+					"ceph tell 84.1fff query": `
+{
+  "state": "active+clean",
+  "info": {
+    "stats": {
+      "stat_sum": {
+        "num_objects_recovered": 456
+      }
+    }
+  }
+}`,
+				},
 			},
-			regexes: []*regexp.Regexp{
-				regexp.MustCompile(`ceph_pg_objects_recovered{cluster="ceph",pgid="84.1fff"} 123`),
+			regExp: []*regexp.Regexp{
+				regexp.MustCompile(`ceph_pg_objects_recovered{cluster="ceph",pgid="84.1fff"} 456`),
+			},
+		},
+		{
+			cmdOut: []map[string]string{
+				{
+					"ceph pg dump pgs_brief": `
+[
+  {
+    "acting": [
+      40,
+      41,
+      42,
+      43
+    ],
+    "acting_primary": 40,
+    "pgid": "85.1fff",
+    "state": "active+remapped+backfill_wait"
+  }
+]`,
+					"ceph tell 85.1fff query": `
+{
+  "state": "active+remapped+backfill_wait",
+  "info": {
+    "stats": {
+      "stat_sum": {
+        "num_objects_recovered": 100
+      }
+    }
+  }
+}`,
+				},
+				{
+					"ceph pg dump pgs_brief": `
+[
+  {
+    "acting": [
+      40,
+      41,
+      42,
+      43
+    ],
+    "acting_primary": 40,
+    "pgid": "85.1fff",
+    "state": "active+remapped+backfilling"
+  }
+]`,
+					"ceph tell 85.1fff query": `
+{
+  "state": "active+remapped+backfilling",
+  "info": {
+    "stats": {
+      "stat_sum": {
+        "num_objects_recovered": 100
+      }
+    }
+  },
+  "recovery_state": [
+    {
+      "enter_time": "2019-07-08 17:58:05.892834",
+      "name": "Started/Primary/Active",
+      "recovery_progress": {
+        "backfill_targets": [
+          "44(1)",
+          "45(2)"
+        ]
+      }
+    }
+  ]
+}`,
+				},
+				{
+					"ceph pg dump pgs_brief": `
+[
+  {
+    "acting": [
+      40,
+      41,
+      42,
+      43
+    ],
+    "acting_primary": 40,
+    "pgid": "85.1fff",
+    "state": "active+remapped+backfilling"
+  }
+]`,
+					"ceph tell 85.1fff query": `
+{
+  "state": "active+remapped+backfilling",
+  "info": {
+    "stats": {
+      "stat_sum": {
+        "num_objects_recovered": 200
+      }
+    }
+  },
+  "recovery_state": [
+    {
+      "enter_time": "2019-07-08 17:58:05.892834",
+      "name": "Started/Primary/Active",
+      "recovery_progress": {
+        "backfill_targets": [
+          "44(1)"
+        ]
+      }
+    }
+  ]
+}`,
+				},
+				{
+					"ceph pg dump pgs_brief": `
+[
+  {
+    "acting": [
+      40,
+      41,
+      42,
+      43
+    ],
+    "acting_primary": 40,
+    "pgid": "85.1fff",
+    "state": "active+clean"
+  }
+]`,
+					"ceph tell 85.1fff query": `
+{
+  "state": "active+clean",
+  "info": {
+    "stats": {
+      "stat_sum": {
+        "num_objects_recovered": 300
+      }
+    }
+  }
+}`,
+				},
+			},
+			regExp: []*regexp.Regexp{
+				regexp.MustCompile(`ceph_osd_objects_backfilled{cluster="ceph",osd="osd.44",pgid="85.1fff"} 150`),
+				regexp.MustCompile(`ceph_osd_objects_backfilled{cluster="ceph",osd="osd.45",pgid="85.1fff"} 50`),
 			},
 		},
 	} {
 		func() {
-			collector := NewOSDCollector(NewNoopConnWithCmdOut(tt.cmdOut), "ceph")
+			conn := NewNoopConnWithCmdOut(tt.cmdOut)
+			collector := NewOSDCollector(conn, "ceph")
 			if err := prometheus.Register(collector); err != nil {
 				t.Fatalf("collector failed to register: %s", err)
 			}
@@ -611,18 +798,22 @@ func TestOSDCollector(t *testing.T) {
 
 			var buf []byte
 
-			resp, err := http.Get(server.URL)
-			if err != nil {
-				t.Fatalf("unexpected failed response from prometheus: %s", err)
-			}
-			defer resp.Body.Close()
+			for i := 0; i < len(tt.cmdOut); i++ {
+				resp, err := http.Get(server.URL)
+				if err != nil {
+					t.Fatalf("unexpected failed response from prometheus: %s", err)
+				}
+				defer resp.Body.Close()
 
-			buf, err = ioutil.ReadAll(resp.Body)
-			if err != nil {
-				t.Fatalf("failed reading server response: %s", err)
+				buf, err = ioutil.ReadAll(resp.Body)
+				if err != nil {
+					t.Fatalf("failed reading server response: %s", err)
+				}
+
+				conn.IncIteration()
 			}
 
-			for _, re := range tt.regexes {
+			for _, re := range tt.regExp {
 				if !re.Match(buf) {
 					t.Errorf("failed matching: %q", re)
 				}


### PR DESCRIPTION
This PR includes below changes:
* Add a counter for number of objects backfilled for an OSD
* Add support for `NoopConn` to have multiple iterations with commands / expected outputs.