### PR TITLE
Metric Fix: cluster_objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 dist: bionic
 
 go:
-  - 1.9.2
+  - 1.13
 
 env:
   - DOCKER_TAG=$TRAVIS_TAG

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
 
 RUN \
   mkdir -p /goroot && \
-  curl https://storage.googleapis.com/golang/go1.9.2.linux-amd64.tar.gz | tar xvzf - -C /goroot --strip-components=1
+  curl https://storage.googleapis.com/golang/go1.13.linux-amd64.tar.gz | tar xvzf - -C /goroot --strip-components=1
 
 ADD . $APPLOC
 WORKDIR $APPLOC

--- a/Makefile.COMMON
+++ b/Makefile.COMMON
@@ -44,7 +44,7 @@ SRC    ?= $(shell find . -type f -name "*.go" ! -path "./.build/*")
 GOOS   ?= $(shell uname | tr A-Z a-z)
 GOARCH ?= $(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m)))
 
-GO_VERSION ?= 1.5.3
+GO_VERSION ?= 1.13
 
 # Check for the correct version of go in the path. If we find it, use it.
 # Otherwise, prepare to build go locally.

--- a/collectors/cluster_usage_test.go
+++ b/collectors/cluster_usage_test.go
@@ -38,15 +38,13 @@ func TestClusterUsage(t *testing.T) {
 	"stats": {
 		"total_bytes": 10,
 		"total_used_bytes": 6,
-		"total_avail_bytes": 4,
-		"total_objects": 1
+		"total_avail_bytes": 4
 	}
 }`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`ceph_cluster_capacity_bytes{cluster="ceph"} 10`),
 				regexp.MustCompile(`ceph_cluster_used_bytes{cluster="ceph"} 6`),
 				regexp.MustCompile(`ceph_cluster_available_bytes{cluster="ceph"} 4`),
-				regexp.MustCompile(`ceph_cluster_objects{cluster="ceph"} 1`),
 			},
 			reUnmatch: []*regexp.Regexp{},
 		},
@@ -55,15 +53,13 @@ func TestClusterUsage(t *testing.T) {
 {
 	"stats": {
 		"total_used_bytes": 6,
-		"total_avail_bytes": 4,
-		"total_objects": 1
+		"total_avail_bytes": 4
 	}
 }`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`ceph_cluster_capacity_bytes{cluster="ceph"} 0`),
 				regexp.MustCompile(`ceph_cluster_used_bytes{cluster="ceph"} 6`),
 				regexp.MustCompile(`ceph_cluster_available_bytes{cluster="ceph"} 4`),
-				regexp.MustCompile(`ceph_cluster_objects{cluster="ceph"} 1`),
 			},
 			reUnmatch: []*regexp.Regexp{},
 		},
@@ -72,15 +68,13 @@ func TestClusterUsage(t *testing.T) {
 {
 	"stats": {
 		"total_bytes": 10,
-		"total_avail_bytes": 4,
-		"total_objects": 1
+		"total_avail_bytes": 4
 	}
 }`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`ceph_cluster_capacity_bytes{cluster="ceph"} 10`),
 				regexp.MustCompile(`ceph_cluster_used_bytes{cluster="ceph"} 0`),
 				regexp.MustCompile(`ceph_cluster_available_bytes{cluster="ceph"} 4`),
-				regexp.MustCompile(`ceph_cluster_objects{cluster="ceph"} 1`),
 			},
 			reUnmatch: []*regexp.Regexp{},
 		},
@@ -89,15 +83,13 @@ func TestClusterUsage(t *testing.T) {
 {
 	"stats": {
 		"total_bytes": 10,
-		"total_used_bytes": 6,
-		"total_objects": 1
+		"total_used_bytes": 6
 	}
 }`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`ceph_cluster_capacity_bytes{cluster="ceph"} 10`),
 				regexp.MustCompile(`ceph_cluster_used_bytes{cluster="ceph"} 6`),
 				regexp.MustCompile(`ceph_cluster_available_bytes{cluster="ceph"} 0`),
-				regexp.MustCompile(`ceph_cluster_objects{cluster="ceph"} 1`),
 			},
 			reUnmatch: []*regexp.Regexp{},
 		},
@@ -114,7 +106,6 @@ func TestClusterUsage(t *testing.T) {
 				regexp.MustCompile(`ceph_cluster_capacity_bytes{cluster="ceph"} 10`),
 				regexp.MustCompile(`ceph_cluster_used_bytes{cluster="ceph"} 6`),
 				regexp.MustCompile(`ceph_cluster_available_bytes{cluster="ceph"} 4`),
-				regexp.MustCompile(`ceph_cluster_objects{cluster="ceph"} 0`),
 			},
 			reUnmatch: []*regexp.Regexp{},
 		},
@@ -124,8 +115,7 @@ func TestClusterUsage(t *testing.T) {
 	"stats": {{{
 		"total_bytes": 10,
 		"total_used_bytes": 6,
-		"total_avail_bytes": 4,
-		"total_objects": 1
+		"total_avail_bytes": 4
 	}
 }`,
 			reMatch: []*regexp.Regexp{},
@@ -133,7 +123,6 @@ func TestClusterUsage(t *testing.T) {
 				regexp.MustCompile(`ceph_cluster_capacity_bytes{cluster="ceph"}`),
 				regexp.MustCompile(`ceph_cluster_used_bytes{cluster="ceph"}`),
 				regexp.MustCompile(`ceph_cluster_available_bytes{cluster="ceph"}`),
-				regexp.MustCompile(`ceph_cluster_objects{cluster="ceph"}`),
 			},
 		},
 	} {

--- a/collectors/health_test.go
+++ b/collectors/health_test.go
@@ -370,11 +370,12 @@ $ sudo ceph -s
 			"num_remapped_pgs": 0
 		}
 	},
-	"pgmap": { "num_pgs": 52000 },
+	"pgmap": { "num_pgs": 52000, "num_objects": 13156 },
 	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "7 pgs undersized"}]}
 }`,
 			regexes: []*regexp.Regexp{
 				regexp.MustCompile(`total_pgs{cluster="ceph"} 52000`),
+				regexp.MustCompile(`cluster_objects{cluster="ceph"} 13156`),
 			},
 		},
 		{
@@ -399,7 +400,8 @@ $ sudo ceph -s
 				"count": 5
 			}
 		],
-		"num_pgs": 52000
+		"num_pgs": 52000,
+		"num_objects": 13156
 	},
 	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "7 pgs undersized"}]}
 }`,
@@ -407,6 +409,7 @@ $ sudo ceph -s
 				regexp.MustCompile(`active_pgs{cluster="ceph"} 7`),
 				regexp.MustCompile(`scrubbing_pgs{cluster="ceph"} 2`),
 				regexp.MustCompile(`deep_scrubbing_pgs{cluster="ceph"} 5`),
+				regexp.MustCompile(`cluster_objects{cluster="ceph"} 13156`),
 			},
 		},
 		{


### PR DESCRIPTION
cluster_objects was collected from output of the ceph df detail command in luminous. In nautilus, the output no longer contains the total_objects stat. For nautilus, the cluster_objects metric will be collected using ceph health command, which returns the num_objects stat.