### PR TITLE
restore 1f2df8db38b2a400758ef37ed2a531965ee120fe

### DIFF
--- a/collectors/osd.go
+++ b/collectors/osd.go
@@ -395,7 +395,7 @@ type cephOSDDF struct {
 	} `json:"summary"`
 }
 
-type cephOSDPerf struct {
+type cephPerfStat struct {
 	PerfInfo []struct {
 		ID    json.Number `json:"id"`
 		Stats struct {
@@ -403,6 +403,10 @@ type cephOSDPerf struct {
 			ApplyLatency  json.Number `json:"apply_latency_ms"`
 		} `json:"perf_stats"`
 	} `json:"osd_perf_infos"`
+}
+
+type CephOSDPerfStat struct {
+	cephPerfStat `json:"osdstats"`
 }
 
 type cephOSDDump struct {
@@ -583,7 +587,7 @@ func (o *OSDCollector) collectOSDPerf() error {
 		return err
 	}
 
-	osdPerf := &cephOSDPerf{}
+	osdPerf := &CephOSDPerfStat{}
 	if err := json.Unmarshal(buf, osdPerf); err != nil {
 		return err
 	}

--- a/collectors/osd_test.go
+++ b/collectors/osd_test.go
@@ -164,43 +164,45 @@ func TestOSDCollector(t *testing.T) {
 			cmdOut: map[string]string{
 				"ceph osd perf": `
 {
-	"osd_perf_infos": [
-		{
-			"id": 4,
-			"perf_stats": {
-				"commit_latency_ms": 0,
-				"apply_latency_ms": 0
+	"osdstats": {
+		"osd_perf_infos": [
+			{
+				"id": 4,
+				"perf_stats": {
+					"commit_latency_ms": 0,
+					"apply_latency_ms": 0
+				}
+			},
+			{
+				"id": 3,
+				"perf_stats": {
+					"commit_latency_ms": 1,
+					"apply_latency_ms": 64
+				}
+			},
+			{
+				"id": 2,
+				"perf_stats": {
+					"commit_latency_ms": 2,
+					"apply_latency_ms": 79
+				}
+			},
+			{
+				"id": 1,
+				"perf_stats": {
+					"commit_latency_ms": 2,
+					"apply_latency_ms": 39
+				}
+			},
+			{
+				"id": 0,
+				"perf_stats": {
+					"commit_latency_ms": 2,
+					"apply_latency_ms": 31
+				}
 			}
-		},
-		{
-			"id": 3,
-			"perf_stats": {
-				"commit_latency_ms": 1,
-				"apply_latency_ms": 64
-			}
-		},
-		{
-			"id": 2,
-			"perf_stats": {
-				"commit_latency_ms": 2,
-				"apply_latency_ms": 79
-			}
-		},
-		{
-			"id": 1,
-			"perf_stats": {
-				"commit_latency_ms": 2,
-				"apply_latency_ms": 39
-			}
-		},
-		{
-			"id": 0,
-			"perf_stats": {
-				"commit_latency_ms": 2,
-				"apply_latency_ms": 31
-			}
-		}
-	]
+		]
+	}
 }`,
 			},
 			regexes: []*regexp.Regexp{


### PR DESCRIPTION
fixes: https://github.com/digitalocean/ceph_exporter/issues/136 

OSD perf metrics are not reported with luminous.