### PR TITLE
Allows pg_state gauges to return to 0

### DIFF
--- a/collectors/health_test.go
+++ b/collectors/health_test.go
@@ -40,44 +40,10 @@ func TestClusterHealthCollector(t *testing.T) {
 			"num_remapped_pgs": 0
 		}
 	},
-	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "5 pgs degraded"}]}
-}`,
-			regexes: []*regexp.Regexp{
-				regexp.MustCompile(`degraded_pgs{cluster="ceph"} 5`),
-			},
-		},
-		{
-			input: `
-{
-	"osdmap": {
-		"osdmap": {
-			"num_osds": 0,
-			"num_up_osds": 0,
-			"num_in_osds": 0,
-			"num_remapped_pgs": 0
-		}
-	},
 	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "15 pgs stuck degraded"}]}
 }`,
 			regexes: []*regexp.Regexp{
 				regexp.MustCompile(`stuck_degraded_pgs{cluster="ceph"} 15`),
-			},
-		},
-		{
-			input: `
-{
-	"osdmap": {
-		"osdmap": {
-			"num_osds": 0,
-			"num_up_osds": 0,
-			"num_in_osds": 0,
-			"num_remapped_pgs": 0
-		}
-	},
-	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "6 pgs unclean"}]}
-}`,
-			regexes: []*regexp.Regexp{
-				regexp.MustCompile(`unclean_pgs{cluster="ceph"} 6`),
 			},
 		},
 		{
@@ -108,44 +74,10 @@ func TestClusterHealthCollector(t *testing.T) {
 			"num_remapped_pgs": 0
 		}
 	},
-	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "7 pgs undersized"}]}
-}`,
-			regexes: []*regexp.Regexp{
-				regexp.MustCompile(`undersized_pgs{cluster="ceph"} 7`),
-			},
-		},
-		{
-			input: `
-{
-	"osdmap": {
-		"osdmap": {
-			"num_osds": 0,
-			"num_up_osds": 0,
-			"num_in_osds": 0,
-			"num_remapped_pgs": 0
-		}
-	},
 	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "17 pgs stuck undersized"}]}
 }`,
 			regexes: []*regexp.Regexp{
 				regexp.MustCompile(`stuck_undersized_pgs{cluster="ceph"} 17`),
-			},
-		},
-		{
-			input: `
-{
-	"osdmap": {
-		"osdmap": {
-			"num_osds": 0,
-			"num_up_osds": 0,
-			"num_in_osds": 0,
-			"num_remapped_pgs": 0
-		}
-	},
-	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "8 pgs stale"}]}
-}`,
-			regexes: []*regexp.Regexp{
-				regexp.MustCompile(`stale_pgs{cluster="ceph"} 8`),
 			},
 		},
 		{
@@ -477,7 +409,6 @@ $ sudo ceph -s
 }`,
 			regexes: []*regexp.Regexp{
 				regexp.MustCompile(`degraded_objects{cluster="ceph"} 1.54443937e\+08`),
-				regexp.MustCompile(`unclean_pgs{cluster="ceph"} 4886`),
 				regexp.MustCompile(`health_status_interp{cluster="ceph"} 1`),
 			},
 		},

--- a/collectors/monitors.go
+++ b/collectors/monitors.go
@@ -271,13 +271,13 @@ func (m *MonitorCollector) collect() error {
 		return err
 	}
 
-        // Reset daemon specifc metrics; daemons can leave the cluster
-        m.TotalKBs.Reset()
-        m.UsedKBs.Reset()
-        m.AvailKBs.Reset()
-        m.PercentAvail.Reset()
-        m.Latency.Reset()
-        m.ClockSkew.Reset()
+	// Reset daemon specifc metrics; daemons can leave the cluster
+	m.TotalKBs.Reset()
+	m.UsedKBs.Reset()
+	m.AvailKBs.Reset()
+	m.PercentAvail.Reset()
+	m.Latency.Reset()
+	m.ClockSkew.Reset()
 
 	for _, healthService := range stats.Health.Health.HealthServices {
 		for _, monstat := range healthService.Mons {

--- a/collectors/pool_usage.go
+++ b/collectors/pool_usage.go
@@ -210,16 +210,16 @@ func (p *PoolUsageCollector) collect() error {
 		return err
 	}
 
-        // Reset pool specfic metrics, pools can be removed
-        p.UsedBytes.Reset()
-        p.RawUsedBytes.Reset()
-        p.MaxAvail.Reset()
-        p.Objects.Reset()
-        p.DirtyObjects.Reset()
-        p.ReadIO.Reset()
-        p.ReadBytes.Reset()
-        p.WriteIO.Reset()
-        p.WriteBytes.Reset()
+	// Reset pool specfic metrics, pools can be removed
+	p.UsedBytes.Reset()
+	p.RawUsedBytes.Reset()
+	p.MaxAvail.Reset()
+	p.Objects.Reset()
+	p.DirtyObjects.Reset()
+	p.ReadIO.Reset()
+	p.ReadBytes.Reset()
+	p.WriteIO.Reset()
+	p.WriteBytes.Reset()
 
 	for _, pool := range stats.Pools {
 		p.UsedBytes.WithLabelValues(pool.Name).Set(pool.Stats.BytesUsed)


### PR DESCRIPTION
This does change the default behaviour for these metrics. Previously, these time series did not exist until ceph_exporter observed a pg in the given state. Now these time series will always exist and be zero whenever ceph_exporter sees no pgs in the given state.

Also run `go fmt`, because we're not animals. :heart: 