### PR TITLE
fix renamed in Nautilus metric

### DIFF
--- a/collectors/pool_usage.go
+++ b/collectors/pool_usage.go
@@ -186,7 +186,7 @@ type cephPoolStats struct {
 		ID    int    `json:"id"`
 		Stats struct {
 			BytesUsed    float64 `json:"bytes_used"`
-			RawBytesUsed float64 `json:"raw_bytes_used"`
+			StoredRaw    float64 `json:"stored_raw"`
 			MaxAvail     float64 `json:"max_avail"`
 			Objects      float64 `json:"objects"`
 			DirtyObjects float64 `json:"dirty"`
@@ -223,7 +223,7 @@ func (p *PoolUsageCollector) collect() error {
 
 	for _, pool := range stats.Pools {
 		p.UsedBytes.WithLabelValues(pool.Name).Set(pool.Stats.BytesUsed)
-		p.RawUsedBytes.WithLabelValues(pool.Name).Set(pool.Stats.RawBytesUsed)
+		p.RawUsedBytes.WithLabelValues(pool.Name).Set(pool.Stats.StoredRaw)
 		p.MaxAvail.WithLabelValues(pool.Name).Set(pool.Stats.MaxAvail)
 		p.Objects.WithLabelValues(pool.Name).Set(pool.Stats.Objects)
 		p.DirtyObjects.WithLabelValues(pool.Name).Set(pool.Stats.DirtyObjects)

--- a/collectors/pool_usage_test.go
+++ b/collectors/pool_usage_test.go
@@ -140,8 +140,8 @@ func TestPoolUsageCollector(t *testing.T) {
 		{
 			input: `
 {"pools": [
-	{"id": 32, "name": "cinder_sas", "stats": { "bytes_used": 71525351713, "dirty": 17124, "kb_used": 69848977, "max_avail": 6038098673664, "objects": 17124, "quota_bytes": 0, "quota_objects": 0, "raw_bytes_used": 214576054272, "rd": 348986643, "rd_bytes": 3288983853056, "wr": 45792703, "wr_bytes": 272268791808 }},
-	{"id": 33, "name": "cinder_ssd", "stats": { "bytes_used": 68865564849, "dirty": 16461, "kb_used": 67251529, "max_avail": 186205372416, "objects": 16461, "quota_bytes": 0, "quota_objects": 0, "raw_bytes_used": 206596702208, "rd": 347, "rd_bytes": 12899328, "wr": 26721, "wr_bytes": 68882356224 }}
+	{"id": 32, "name": "cinder_sas", "stats": { "bytes_used": 71525351713, "dirty": 17124, "kb_used": 69848977, "max_avail": 6038098673664, "objects": 17124, "quota_bytes": 0, "quota_objects": 0, "stored_raw": 214576054272, "rd": 348986643, "rd_bytes": 3288983853056, "wr": 45792703, "wr_bytes": 272268791808 }},
+	{"id": 33, "name": "cinder_ssd", "stats": { "bytes_used": 68865564849, "dirty": 16461, "kb_used": 67251529, "max_avail": 186205372416, "objects": 16461, "quota_bytes": 0, "quota_objects": 0, "stored_raw": 206596702208, "rd": 347, "rd_bytes": 12899328, "wr": 26721, "wr_bytes": 68882356224 }}
 ]}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`ceph_pool_available_bytes{cluster="ceph",pool="cinder_sas"} 6.038098673664e\+12`),


### PR DESCRIPTION
According to https://docs.ceph.com/docs/master/releases/nautilus/:
```
‘raw bytes used’ column renamed to “stored_raw”. Totals of user data
over all OSD excluding degraded.
```
Updating the internal metric accordingly.