### PR TITLE
Capture new percent_used pool metric

### DIFF
--- a/collectors/pool_usage.go
+++ b/collectors/pool_usage.go
@@ -21,8 +21,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// PoolUsageCollector displays statistics about each pool we have created
-// in the ceph cluster.
+// PoolUsageCollector displays statistics about each pool in the Ceph cluster.
 type PoolUsageCollector struct {
 	conn Conn
 
@@ -37,6 +36,9 @@ type PoolUsageCollector struct {
 	// MaxAvail tracks the amount of bytes currently free for the pool,
 	// which depends on the replication settings for the pool in question.
 	MaxAvail *prometheus.GaugeVec
+
+	// PercentUsed is the percentage of raw space available to the pool currently in use
+	PercentUsed *prometheus.GaugeVec
 
 	// Objects shows the no. of RADOS objects created within the pool.
 	Objects *prometheus.GaugeVec
@@ -98,7 +100,17 @@ func NewPoolUsageCollector(conn Conn, cluster string) *PoolUsageCollector {
 				Namespace:   cephNamespace,
 				Subsystem:   subSystem,
 				Name:        "available_bytes",
-				Help:        "Free space for this ceph pool",
+				Help:        "Free space for this pool",
+				ConstLabels: labels,
+			},
+			poolLabel,
+		),
+		PercentUsed: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace:   cephNamespace,
+				Subsystem:   subSystem,
+				Name:        "percent_used",
+				Help:        "Percentage of the capacity available to this pool that is used by this pool",
 				ConstLabels: labels,
 			},
 			poolLabel,
@@ -171,6 +183,7 @@ func (p *PoolUsageCollector) collectorList() []prometheus.Collector {
 		p.UsedBytes,
 		p.RawUsedBytes,
 		p.MaxAvail,
+		p.PercentUsed,
 		p.Objects,
 		p.DirtyObjects,
 		p.ReadIO,
@@ -188,6 +201,7 @@ type cephPoolStats struct {
 			BytesUsed    float64 `json:"bytes_used"`
 			RawBytesUsed float64 `json:"raw_bytes_used"`
 			MaxAvail     float64 `json:"max_avail"`
+			PercentUsed  float64 `json:"percent_used"`
 			Objects      float64 `json:"objects"`
 			DirtyObjects float64 `json:"dirty"`
 			ReadIO       float64 `json:"rd"`
@@ -214,6 +228,7 @@ func (p *PoolUsageCollector) collect() error {
 	p.UsedBytes.Reset()
 	p.RawUsedBytes.Reset()
 	p.MaxAvail.Reset()
+	p.PercentUsed.Reset()
 	p.Objects.Reset()
 	p.DirtyObjects.Reset()
 	p.ReadIO.Reset()
@@ -225,6 +240,7 @@ func (p *PoolUsageCollector) collect() error {
 		p.UsedBytes.WithLabelValues(pool.Name).Set(pool.Stats.BytesUsed)
 		p.RawUsedBytes.WithLabelValues(pool.Name).Set(pool.Stats.RawBytesUsed)
 		p.MaxAvail.WithLabelValues(pool.Name).Set(pool.Stats.MaxAvail)
+		p.PercentUsed.WithLabelValues(pool.Name).Set(pool.Stats.PercentUsed)
 		p.Objects.WithLabelValues(pool.Name).Set(pool.Stats.Objects)
 		p.DirtyObjects.WithLabelValues(pool.Name).Set(pool.Stats.DirtyObjects)
 		p.ReadIO.WithLabelValues(pool.Name).Set(pool.Stats.ReadIO)

--- a/collectors/pool_usage_test.go
+++ b/collectors/pool_usage_test.go
@@ -140,10 +140,10 @@ func TestPoolUsageCollector(t *testing.T) {
 		{
 			input: `
 {"pools": [
-	{"name": "ssd", "id": 11, "stats": {"percent_used": 0.067462295293807983, "objects": 5, "rd": 4, "wr": 6}}
+	{"name": "ssd", "id": 11, "stats": {"percent_used": 1.3390908861765638e-06, "objects": 5, "rd": 4, "wr": 6}}
 ]}`,
 			reMatch: []*regexp.Regexp{
-				regexp.MustCompile(`pool_percent_used{cluster="ceph",pool="ssd"} 0.067462295293807983`),
+				regexp.MustCompile(`pool_percent_used{cluster="ceph",pool="ssd"} 1.3390908861765638e\-06`),
 			},
 		},
 		{

--- a/collectors/pool_usage_test.go
+++ b/collectors/pool_usage_test.go
@@ -140,6 +140,15 @@ func TestPoolUsageCollector(t *testing.T) {
 		{
 			input: `
 {"pools": [
+	{"name": "ssd", "id": 11, "stats": {"percent_used": 0.067462295293807983, "objects": 5, "rd": 4, "wr": 6}}
+]}`,
+			reMatch: []*regexp.Regexp{
+				regexp.MustCompile(`pool_percent_used{cluster="ceph",pool="ssd"} 0.067462295293807983`),
+			},
+		},
+		{
+			input: `
+{"pools": [
 	{"id": 32, "name": "cinder_sas", "stats": { "bytes_used": 71525351713, "dirty": 17124, "kb_used": 69848977, "max_avail": 6038098673664, "objects": 17124, "quota_bytes": 0, "quota_objects": 0, "raw_bytes_used": 214576054272, "rd": 348986643, "rd_bytes": 3288983853056, "wr": 45792703, "wr_bytes": 272268791808 }},
 	{"id": 33, "name": "cinder_ssd", "stats": { "bytes_used": 68865564849, "dirty": 16461, "kb_used": 67251529, "max_avail": 186205372416, "objects": 16461, "quota_bytes": 0, "quota_objects": 0, "raw_bytes_used": 206596702208, "rd": 347, "rd_bytes": 12899328, "wr": 26721, "wr_bytes": 68882356224 }}
 ]}`,


### PR DESCRIPTION
The Ceph upstream PR that changed around the raw/used stats also introduced a per-pool percent used metric in the range [0-1]. This PR exposes that metric and makes minor tweaks to a comment and a help string.

Tested against `ceph version 14.2.7 (3d58626ebeec02d8385a4cefb92c6cbc3a45bfe8) nautilus (stable)`


@ssobolewski @robbat2 @alram 