### PR TITLE
Capture new percent_used pool metric and copy over mgr metrics from the Luminous branch

### DIFF
--- a/collectors/health.go
+++ b/collectors/health.go
@@ -227,6 +227,12 @@ type ClusterHealthCollector struct {
 
 	// CachePromoteIOOps shows the rate of operations promoting objects to the cache pool.
 	CachePromoteIOOps prometheus.Gauge
+
+	// MgrsActive shows the number of active mgrs, can be either 0 or 1.
+	MgrsActive prometheus.Gauge
+
+	// MgrsNum shows the total number of mgrs, including standbys.
+	MgrsNum prometheus.Gauge
 }
 
 const (
@@ -785,6 +791,22 @@ func NewClusterHealthCollector(conn Conn, cluster string) *ClusterHealthCollecto
 				ConstLabels: labels,
 			},
 		),
+		MgrsActive: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace:   cephNamespace,
+				Name:        "mgrs_active",
+				Help:        "Count of active mgrs, can be either 0 or 1",
+				ConstLabels: labels,
+			},
+		),
+		MgrsNum: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace:   cephNamespace,
+				Name:        "mgrs",
+				Help:        "Total number of mgrs, including standbys",
+				ConstLabels: labels,
+			},
+		),
 	}
 }
 
@@ -846,6 +868,8 @@ func (c *ClusterHealthCollector) metricsList() []prometheus.Metric {
 		c.CacheFlushIORate,
 		c.CacheEvictIORate,
 		c.CachePromoteIOOps,
+		c.MgrsActive,
+		c.MgrsNum,
 	}
 }
 
@@ -898,6 +922,12 @@ type cephHealthStats struct {
 			States string  `json:"state_name"`
 		} `json:"pgs_by_state"`
 	} `json:"pgmap"`
+	MgrMap struct {
+		ActiveName string `json:"active_name"`
+		StandBys   []struct {
+			Name string `json:"name"`
+		} `json:"standbys"`
+	} `json:"mgrmap"`
 }
 
 type cephHealthDetailStats struct {
@@ -1222,6 +1252,14 @@ func (c *ClusterHealthCollector) collect(ch chan<- prometheus.Metric) error {
 	c.RemappedPGs.Set(stats.OSDMap.OSDMap.NumRemappedPGs)
 	c.TotalPGs.Set(stats.PGMap.NumPGs)
 	c.Objects.Set(stats.PGMap.TotalObjects)
+
+	activeMgr := 0
+	if len(stats.MgrMap.ActiveName) > 0 {
+		activeMgr = 1
+	}
+
+	c.MgrsActive.Set(float64(activeMgr))
+	c.MgrsNum.Set(float64(activeMgr + len(stats.MgrMap.StandBys)))
 
 	return nil
 }

--- a/collectors/health_test.go
+++ b/collectors/health_test.go
@@ -641,6 +641,55 @@ $ sudo ceph -s
 				regexp.MustCompile(`pg_state{cluster="ceph",state="down"} 37`),
 			},
 		},
+		{
+			input: `
+{
+    "mgrmap": {
+        "epoch": 627,
+        "active_gid": 48000003,
+        "active_name": "mon03",
+        "active_addr": "10.0.0.3:6800/1746",
+        "available": true,
+        "standbys": [
+            {
+                "gid": 48000001,
+                "name": "mon01",
+                "available_modules": [
+                    "balancer",
+                    "dashboard",
+                    "influx"
+                ]
+            },
+            {
+                "gid": 48000002,
+                "name": "mon02",
+                "available_modules": [
+                    "balancer",
+                    "dashboard",
+                    "influx"
+                ]
+            }
+        ],
+        "modules": [
+            "dashboard",
+            "restful",
+            "status"
+        ],
+        "available_modules": [
+            "balancer",
+            "dashboard",
+            "influx"
+        ],
+        "services": {
+            "dashboard": "http://mon01:7000/"
+        }
+    }
+}`,
+			regexes: []*regexp.Regexp{
+				regexp.MustCompile(`mgrs_active{cluster="ceph"} 1`),
+				regexp.MustCompile(`mgrs{cluster="ceph"} 3`),
+			},
+		},
 	} {
 		func() {
 			collector := NewClusterHealthCollector(NewNoopConn(tt.input), "ceph")

--- a/collectors/pool_usage.go
+++ b/collectors/pool_usage.go
@@ -105,11 +105,11 @@ func NewPoolUsageCollector(conn Conn, cluster string) *PoolUsageCollector {
 			},
 			poolLabel,
 		),
-		MaxAvail: prometheus.NewGaugeVec(
+		PercentUsed: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace:   cephNamespace,
 				Subsystem:   subSystem,
-				Name:        "percentage_used",
+				Name:        "percent_used",
 				Help:        "Percentage of the capacity available to this pool that is used by this pool",
 				ConstLabels: labels,
 			},

--- a/collectors/pool_usage_test.go
+++ b/collectors/pool_usage_test.go
@@ -140,6 +140,15 @@ func TestPoolUsageCollector(t *testing.T) {
 		{
 			input: `
 {"pools": [
+	{"name": "ssd", "id": 11, "stats": {"percent_used": 1.3390908861765638e-06, "objects": 5, "rd": 4, "wr": 6}}
+]}`,
+			reMatch: []*regexp.Regexp{
+				regexp.MustCompile(`pool_percent_used{cluster="ceph",pool="ssd"} 1.3390908861765638e\-06`),
+			},
+		},
+		{
+			input: `
+{"pools": [
 	{"id": 32, "name": "cinder_sas", "stats": { "bytes_used": 71525351713, "dirty": 17124, "kb_used": 69848977, "max_avail": 6038098673664, "objects": 17124, "quota_bytes": 0, "quota_objects": 0, "stored_raw": 214576054272, "rd": 348986643, "rd_bytes": 3288983853056, "wr": 45792703, "wr_bytes": 272268791808 }},
 	{"id": 33, "name": "cinder_ssd", "stats": { "bytes_used": 68865564849, "dirty": 16461, "kb_used": 67251529, "max_avail": 186205372416, "objects": 16461, "quota_bytes": 0, "quota_objects": 0, "stored_raw": 206596702208, "rd": 347, "rd_bytes": 12899328, "wr": 26721, "wr_bytes": 68882356224 }}
 ]}`,


### PR DESCRIPTION
The Ceph upstream PR that changed around the raw/used stats also introduced a per-pool percent used metric in the range [0-1]. This PR exposes that metric and makes minor tweaks to a comment and a help string.

I also found that `ceph_mgrs` and `ceph_mgrs_active` were missing, so I copied them over from the `luminous` branch too.

Tested against ceph version 14.2.7 (3d58626ebeec02d8385a4cefb92c6cbc3a45bfe8) nautilus (stable)

@alram This is against the `nautilus` branch.
