### PR TITLE
[luminous] pool: Eliminate bad assumption about crush rule ordering.

### DIFF
--- a/collectors/conn.go
+++ b/collectors/conn.go
@@ -154,6 +154,10 @@ func (n *NoopConn) MonCommand(args []byte) ([]byte, string, error) {
                              "max_size": 10,
                              "steps": [
                                {
+                                 "num": 5,
+                                 "op": "set_chooseleaf_tries"
+                               },
+                               {
                                  "op": "take",
                                  "item": -1,
                                  "item_name": "default"

--- a/collectors/pool.go
+++ b/collectors/pool.go
@@ -317,6 +317,7 @@ func (p *PoolInfoCollector) getCrushRuleToRootMappings() map[int64]string {
 		RuleID int64 `json:"rule_id"`
 		Steps  []struct {
 			ItemName string `json:"item_name"`
+			Op       string `json:"op"`
 		} `json:"steps"`
 	}
 
@@ -329,7 +330,15 @@ func (p *PoolInfoCollector) getCrushRuleToRootMappings() map[int64]string {
 		if len(rule.Steps) == 0 {
 			continue
 		}
-		mappings[rule.RuleID] = rule.Steps[0].ItemName
+		for _, step := range rule.Steps {
+			// Although there can be multiple "take" steps, there
+			// usually aren't in practice. The "take" item isn't
+			// necessarily a crush root, but assuming so is good
+			// enough for most cases.
+			if step.Op == "take" {
+				mappings[rule.RuleID] = step.ItemName
+			}
+		}
 	}
 
 	return mappings


### PR DESCRIPTION
We had assumed that the "take" step came first, but that's not necessarily the case.