### PR TITLE
vendor: Update go-ceph to 0.5.0 for proper Nautilus support.

### DIFF
--- a/collectors/osd.go
+++ b/collectors/osd.go
@@ -896,22 +896,6 @@ func (o *OSDCollector) performPGDumpBrief() error {
 	return nil
 }
 
-func (o *OSDCollector) performPGQuery(pgid string) (*cephPGQuery, error) {
-	cmd := o.cephPGQueryCommand(pgid)
-	buf, _, err := o.conn.PGCommand([]byte(pgid), cmd)
-	if err != nil {
-		log.Printf("failed sending PG command %s: %s", cmd, err)
-		return nil, err
-	}
-
-	pgQuery := cephPGQuery{}
-	if err := json.Unmarshal(buf, &pgQuery); err != nil {
-		return nil, err
-	}
-
-	return &pgQuery, nil
-}
-
 func (o *OSDCollector) collectOSDScrubState(ch chan<- prometheus.Metric) error {
 	// need to reset the PG scrub state since the scrub might have ended within
 	// the last prom scrape interval.

--- a/vendor/github.com/ceph/go-ceph/internal/callbacks/callbacks.go
+++ b/vendor/github.com/ceph/go-ceph/internal/callbacks/callbacks.go
@@ -1,0 +1,64 @@
+package callbacks
+
+import (
+	"sync"
+)
+
+// The logic of this file is largely adapted from:
+// https://github.com/golang/go/wiki/cgo#function-variables
+//
+// Also helpful:
+// https://eli.thegreenplace.net/2019/passing-callbacks-and-pointers-to-cgo/
+
+// Callbacks provides a tracker for data that is to be passed between Go
+// and C callback functions. The Go callback/object may not be passed
+// by a pointer to C code and so instead integer indexes into an internal
+// map are used.
+// Typically the item being added will either be a callback function or
+// a data structure containing a callback function. It is up to the caller
+// to control and validate what "callbacks" get used.
+type Callbacks struct {
+	mutex sync.RWMutex
+	cmap  map[int]interface{}
+}
+
+// New returns a new callbacks tracker.
+func New() *Callbacks {
+	return &Callbacks{cmap: make(map[int]interface{})}
+}
+
+// Add a callback/object to the tracker and return a new index
+// for the object.
+func (cb *Callbacks) Add(v interface{}) int {
+	cb.mutex.Lock()
+	defer cb.mutex.Unlock()
+	// this approach assumes that there are typically very few callbacks
+	// in play at once and can just use the length of the map as our
+	// index. But in case of collisions we fall back to simply incrementing
+	// until we find a free key like in the cgo wiki page.
+	// If this code ever becomes a hot path there's surely plenty of room
+	// for optimization in the future :-)
+	index := len(cb.cmap) + 1
+	for {
+		if _, found := cb.cmap[index]; !found {
+			break
+		}
+		index++
+	}
+	cb.cmap[index] = v
+	return index
+}
+
+// Remove a callback/object given it's index.
+func (cb *Callbacks) Remove(index int) {
+	cb.mutex.Lock()
+	defer cb.mutex.Unlock()
+	delete(cb.cmap, index)
+}
+
+// Lookup returns a mapped callback/object given an index.
+func (cb *Callbacks) Lookup(index int) interface{} {
+	cb.mutex.RLock()
+	defer cb.mutex.RUnlock()
+	return cb.cmap[index]
+}

--- a/vendor/github.com/ceph/go-ceph/internal/callbacks/callbacks_test.go
+++ b/vendor/github.com/ceph/go-ceph/internal/callbacks/callbacks_test.go
@@ -1,0 +1,110 @@
+package callbacks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCallbacks(t *testing.T) {
+	cbks := New()
+	assert.Len(t, cbks.cmap, 0)
+
+	i1 := cbks.Add("foo")
+	i2 := cbks.Add("bar")
+	i3 := cbks.Add("baz")
+	assert.Len(t, cbks.cmap, 3)
+
+	var x interface{}
+	x = cbks.Lookup(i1)
+	assert.NotNil(t, x)
+	if s, ok := x.(string); ok {
+		assert.EqualValues(t, s, "foo")
+	}
+
+	x = cbks.Lookup(5555)
+	assert.Nil(t, x)
+
+	x = cbks.Lookup(i3)
+	assert.NotNil(t, x)
+	if s, ok := x.(string); ok {
+		assert.EqualValues(t, s, "baz")
+	}
+	cbks.Remove(i3)
+	x = cbks.Lookup(i3)
+	assert.Nil(t, x)
+
+	cbks.Remove(i2)
+	x = cbks.Lookup(i2)
+	assert.Nil(t, x)
+
+	cbks.Remove(i1)
+	assert.Len(t, cbks.cmap, 0)
+}
+
+func TestCallbacksIndexing(t *testing.T) {
+	cbks := New()
+	assert.Len(t, cbks.cmap, 0)
+
+	i1 := cbks.Add("foo")
+	i2 := cbks.Add("bar")
+	_ = cbks.Add("baz")
+	_ = cbks.Add("wibble")
+	_ = cbks.Add("wabble")
+	assert.Len(t, cbks.cmap, 5)
+
+	// generally we assume that the callback data will be mostly LIFO
+	// but can't guarantee it. Thus we check that when we remove the
+	// first items inserted into the map there are no subsequent issues
+	cbks.Remove(i1)
+	cbks.Remove(i2)
+	_ = cbks.Add("flim")
+	ilast := cbks.Add("flam")
+	assert.Len(t, cbks.cmap, 5)
+
+	x := cbks.Lookup(ilast)
+	assert.NotNil(t, x)
+	if s, ok := x.(string); ok {
+		assert.EqualValues(t, s, "flam")
+	}
+}
+
+func TestCallbacksData(t *testing.T) {
+	cbks := New()
+	assert.Len(t, cbks.cmap, 0)
+
+	// insert a plain function
+	i1 := cbks.Add(func(v int) int { return v + 1 })
+
+	// insert a type "containing" a function, note that it doesn't
+	// actually have a callable function. Users of the type must
+	// check that themselves
+	type flup struct {
+		Stuff int
+		Junk  func(int, int) error
+	}
+	i2 := cbks.Add(flup{
+		Stuff: 55,
+	})
+
+	// did we get a function back
+	x1 := cbks.Lookup(i1)
+	if assert.NotNil(t, x1) {
+		if f, ok := x1.(func(v int) int); ok {
+			assert.Equal(t, 2, f(1))
+		} else {
+			t.Fatalf("conversion failed")
+		}
+	}
+
+	// did we get our data structure back
+	x2 := cbks.Lookup(i2)
+	if assert.NotNil(t, x2) {
+		if d, ok := x2.(flup); ok {
+			assert.Equal(t, 55, d.Stuff)
+			assert.Nil(t, d.Junk)
+		} else {
+			t.Fatalf("conversion failed")
+		}
+	}
+}

--- a/vendor/github.com/ceph/go-ceph/internal/cutil/command_input.go
+++ b/vendor/github.com/ceph/go-ceph/internal/cutil/command_input.go
@@ -1,0 +1,62 @@
+package cutil
+
+/*
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"unsafe"
+)
+
+// CommandInput can be used to manage the input to ceph's *_command functions.
+type CommandInput struct {
+	cmd   []*C.char
+	inbuf []byte
+}
+
+// NewCommandInput creates C-level pointers from go byte buffers suitable
+// for passing off to ceph's *_command functions.
+func NewCommandInput(cmd [][]byte, inputBuffer []byte) *CommandInput {
+	ci := &CommandInput{
+		cmd:   make([]*C.char, len(cmd)),
+		inbuf: inputBuffer,
+	}
+	for i := range cmd {
+		ci.cmd[i] = C.CString(string(cmd[i]))
+	}
+	return ci
+}
+
+// Free any C memory managed by this CommandInput.
+func (ci *CommandInput) Free() {
+	for i := range ci.cmd {
+		C.free(unsafe.Pointer(ci.cmd[i]))
+	}
+	ci.cmd = nil
+}
+
+// Cmd returns an unsafe wrapper around an array of C-strings.
+func (ci *CommandInput) Cmd() CharPtrPtr {
+	ptr := &ci.cmd[0]
+	return CharPtrPtr(ptr)
+}
+
+// CmdLen returns the length of the array of C-strings returned by
+// Cmd.
+func (ci *CommandInput) CmdLen() SizeT {
+	return SizeT(len(ci.cmd))
+}
+
+// InBuf returns an unsafe wrapper to a C char*.
+func (ci *CommandInput) InBuf() CharPtr {
+	if len(ci.inbuf) == 0 {
+		return nil
+	}
+	return CharPtr(&ci.inbuf[0])
+}
+
+// InBufLen returns the length of the buffer returned by InBuf.
+func (ci *CommandInput) InBufLen() SizeT {
+	return SizeT(len(ci.inbuf))
+}

--- a/vendor/github.com/ceph/go-ceph/internal/cutil/command_input_test.go
+++ b/vendor/github.com/ceph/go-ceph/internal/cutil/command_input_test.go
@@ -1,0 +1,50 @@
+package cutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommandInput(t *testing.T) {
+	t.Run("newAndFree", func(t *testing.T) {
+		ci := NewCommandInput(
+			[][]byte{[]byte("foobar")},
+			nil)
+		ci.Free()
+	})
+	t.Run("cmd", func(t *testing.T) {
+		ci := NewCommandInput(
+			[][]byte{[]byte("foobar")},
+			nil)
+		defer ci.Free()
+		assert.Len(t, ci.cmd, 1)
+		assert.EqualValues(t, 1, ci.CmdLen())
+		assert.NotNil(t, ci.Cmd())
+	})
+	t.Run("cmd2", func(t *testing.T) {
+		ci := NewCommandInput(
+			[][]byte{[]byte("foobar"), []byte("snarf")},
+			nil)
+		defer ci.Free()
+		assert.Len(t, ci.cmd, 2)
+		assert.EqualValues(t, 2, ci.CmdLen())
+		assert.NotNil(t, ci.Cmd())
+	})
+	t.Run("noInBuf", func(t *testing.T) {
+		ci := NewCommandInput(
+			[][]byte{[]byte("foobar")},
+			nil)
+		defer ci.Free()
+		assert.EqualValues(t, 0, ci.InBufLen())
+		assert.Equal(t, CharPtr(nil), ci.InBuf())
+	})
+	t.Run("hasInBuf", func(t *testing.T) {
+		ci := NewCommandInput(
+			[][]byte{[]byte("foobar")},
+			[]byte("original oregano"))
+		defer ci.Free()
+		assert.EqualValues(t, 16, ci.InBufLen())
+		assert.NotEqual(t, CharPtr(nil), ci.InBuf())
+	})
+}

--- a/vendor/github.com/ceph/go-ceph/internal/cutil/command_output.go
+++ b/vendor/github.com/ceph/go-ceph/internal/cutil/command_output.go
@@ -1,0 +1,100 @@
+package cutil
+
+/*
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"unsafe"
+)
+
+// CommandOutput can be used to manage the outputs of ceph's *_command
+// functions.
+type CommandOutput struct {
+	free      FreeFunc
+	outBuf    *C.char
+	outBufLen C.size_t
+	outs      *C.char
+	outsLen   C.size_t
+}
+
+// NewCommandOutput returns an empty CommandOutput. The pointers that
+// a CommandOutput provides can be used to get the results of ceph's
+// *_command functions.
+func NewCommandOutput() *CommandOutput {
+	return &CommandOutput{
+		free: free,
+	}
+}
+
+// SetFreeFunc sets the function used to free memory held by CommandOutput.
+// Not all uses of CommandOutput expect to use the basic C.free function
+// and either require or prefer the use of a custom deallocation function.
+// Use SetFreeFunc to change the free function and return the modified
+// CommandOutput object.
+func (co *CommandOutput) SetFreeFunc(f FreeFunc) *CommandOutput {
+	co.free = f
+	return co
+}
+
+// Free any C memory tracked by this object.
+func (co *CommandOutput) Free() {
+	if co.outBuf != nil {
+		co.free(unsafe.Pointer(co.outBuf))
+	}
+	if co.outs != nil {
+		co.free(unsafe.Pointer(co.outs))
+	}
+}
+
+// OutBuf returns an unsafe wrapper around a pointer to a `char*`.
+func (co *CommandOutput) OutBuf() CharPtrPtr {
+	return CharPtrPtr(&co.outBuf)
+}
+
+// OutBufLen returns an unsafe wrapper around a pointer to a size_t.
+func (co *CommandOutput) OutBufLen() SizeTPtr {
+	return SizeTPtr(&co.outBufLen)
+}
+
+// Outs returns an unsafe wrapper around a pointer to a `char*`.
+func (co *CommandOutput) Outs() CharPtrPtr {
+	return CharPtrPtr(&co.outs)
+}
+
+// OutsLen returns an unsafe wrapper around a pointer to a size_t.
+func (co *CommandOutput) OutsLen() SizeTPtr {
+	return SizeTPtr(&co.outsLen)
+}
+
+// GoValues returns native go values converted from the internal C-language
+// values tracked by this object.
+func (co *CommandOutput) GoValues() (buf []byte, status string) {
+	if co.outBufLen > 0 {
+		buf = C.GoBytes(unsafe.Pointer(co.outBuf), C.int(co.outBufLen))
+	}
+	if co.outsLen > 0 {
+		status = C.GoStringN(co.outs, C.int(co.outsLen))
+	}
+	return buf, status
+}
+
+// testSetString is only used by the unit tests for this file.
+// It is located here due to the restriction on having import "C" in
+// go test files. :-(
+// It mimics a C function that takes a pointer to a
+// string and length and allocates memory and sets the pointers
+// to the new string and its length.
+func testSetString(strp CharPtrPtr, lenp SizeTPtr, s string) {
+	sp := (**C.char)(strp)
+	lp := (*C.size_t)(lenp)
+	*sp = C.CString(s)
+	*lp = C.size_t(len(s))
+}
+
+// free wraps C.free.
+// Required for unit tests that may not use cgo directly.
+func free(p unsafe.Pointer) {
+	C.free(p)
+}

--- a/vendor/github.com/ceph/go-ceph/internal/cutil/command_output_test.go
+++ b/vendor/github.com/ceph/go-ceph/internal/cutil/command_output_test.go
@@ -1,0 +1,56 @@
+package cutil
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommandOutput(t *testing.T) {
+	t.Run("newAndFree", func(t *testing.T) {
+		co := NewCommandOutput()
+		assert.NotNil(t, co)
+		co.Free()
+	})
+	t.Run("setValues", func(t *testing.T) {
+		co := NewCommandOutput()
+		assert.NotNil(t, co)
+		defer co.Free()
+		testSetString(co.OutBuf(), co.OutBufLen(), "i got style")
+		testSetString(co.Outs(), co.OutsLen(), "i got rhythm")
+		b, s := co.GoValues()
+		assert.EqualValues(t, []byte("i got style"), b)
+		assert.EqualValues(t, "i got rhythm", s)
+	})
+	t.Run("setOnlyOutBuf", func(t *testing.T) {
+		co := NewCommandOutput()
+		assert.NotNil(t, co)
+		defer co.Free()
+		testSetString(co.OutBuf(), co.OutBufLen(), "i got style")
+		b, s := co.GoValues()
+		assert.EqualValues(t, []byte("i got style"), b)
+		assert.EqualValues(t, "", s)
+	})
+	t.Run("setOnlyOuts", func(t *testing.T) {
+		co := NewCommandOutput()
+		assert.NotNil(t, co)
+		defer co.Free()
+		testSetString(co.Outs(), co.OutsLen(), "i got rhythm")
+		b, s := co.GoValues()
+		assert.Nil(t, b)
+		assert.EqualValues(t, "i got rhythm", s)
+	})
+	t.Run("customFreeFunc", func(t *testing.T) {
+		callCount := 0
+		co := NewCommandOutput().SetFreeFunc(func(p unsafe.Pointer) {
+			callCount++
+			free(p)
+		})
+		assert.NotNil(t, co)
+		testSetString(co.OutBuf(), co.OutBufLen(), "i got style")
+		testSetString(co.Outs(), co.OutsLen(), "i got rhythm")
+		co.Free()
+		assert.Equal(t, 2, callCount)
+	})
+}

--- a/vendor/github.com/ceph/go-ceph/internal/cutil/splitbuf.go
+++ b/vendor/github.com/ceph/go-ceph/internal/cutil/splitbuf.go
@@ -1,0 +1,49 @@
+package cutil
+
+import "C"
+
+import (
+	"bytes"
+)
+
+// SplitBuffer splits a byte-slice buffer, typically returned from C code,
+// into a slice of strings.
+// The contents of the buffer are assumed to be null-byte separated.
+// If the buffer contains a sequence of null-bytes it will assume that the
+// "space" between the bytes are meant to be empty strings.
+func SplitBuffer(b []byte) []string {
+	return splitBufStrings(b, true)
+}
+
+// SplitSparseBuffer splits a byte-slice buffer, typically returned from C code,
+// into a slice of strings.
+// The contents of the buffer are assumed to be null-byte separated.
+// This function assumes that buffer to be "sparse" such that only non-null-byte
+// strings will be returned, and no "empty" strings exist if null-bytes
+// are found adjacent to each other.
+func SplitSparseBuffer(b []byte) []string {
+	return splitBufStrings(b, false)
+}
+
+// If keepEmpty is true, empty substrings will be returned, by default they are
+// excluded from the results.
+// This is almost certainly a suboptimal implementation, especially for
+// keepEmpty=true case. Optimizing the functions is a job for another day.
+func splitBufStrings(b []byte, keepEmpty bool) []string {
+	values := make([]string, 0)
+	// the final null byte should be the terminating null in C
+	// we never want to preserve the empty string after it
+	if len(b) > 0 && b[len(b)-1] == 0 {
+		b = b[:len(b)-1]
+	}
+	if len(b) == 0 {
+		return values
+	}
+	for _, s := range bytes.Split(b, []byte{0}) {
+		if !keepEmpty && len(s) == 0 {
+			continue
+		}
+		values = append(values, string(s))
+	}
+	return values
+}

--- a/vendor/github.com/ceph/go-ceph/internal/cutil/splitbuf_test.go
+++ b/vendor/github.com/ceph/go-ceph/internal/cutil/splitbuf_test.go
@@ -1,0 +1,70 @@
+package cutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var tbl = []struct {
+	val  []byte
+	res1 []string
+	res2 []string
+}{
+	// simple inputs
+	{
+		val:  []byte("foo\x00bar\x00baz\x00"),
+		res1: []string{"foo", "bar", "baz"},
+		res2: []string{"foo", "bar", "baz"},
+	},
+	// no trailing null bytes
+	{
+		val:  []byte("meow mix"),
+		res1: []string{"meow mix"},
+		res2: []string{"meow mix"},
+	},
+	// one item
+	{
+		val:  []byte("fancy feast\x00"),
+		res1: []string{"fancy feast"},
+		res2: []string{"fancy feast"},
+	},
+	// nuttin dare
+	{
+		val:  []byte(""),
+		res1: []string{},
+		res2: []string{},
+	},
+	// almost nuttin
+	{
+		val:  []byte("\x00"),
+		res1: []string{},
+		res2: []string{},
+	},
+	// how multiple adjacent nulls are handled
+	{
+		val:  []byte("kibbles\x00\x00and\x00bits"),
+		res1: []string{"kibbles", "and", "bits"},
+		res2: []string{"kibbles", "", "and", "bits"},
+	},
+	{
+		val:  []byte("dinki\x00\x00\x00di\x00\x00"),
+		res1: []string{"dinki", "di"},
+		res2: []string{"dinki", "", "", "di", ""},
+	},
+	// starting with a null
+	{
+		val:  []byte("\x00caesar\x00"),
+		res1: []string{"caesar"},
+		res2: []string{"", "caesar"},
+	},
+}
+
+func TestSplitBufStrings(t *testing.T) {
+	for _, x := range tbl {
+		assert.Equal(t, x.res1, SplitSparseBuffer(x.val))
+	}
+	for _, x := range tbl {
+		assert.Equal(t, x.res2, SplitBuffer(x.val))
+	}
+}

--- a/vendor/github.com/ceph/go-ceph/internal/cutil/type_aliases.go
+++ b/vendor/github.com/ceph/go-ceph/internal/cutil/type_aliases.go
@@ -1,0 +1,28 @@
+package cutil
+
+import "C"
+
+import (
+	"unsafe"
+)
+
+// Basic types from C that we can make "public" without too much fuss.
+
+// SizeT wraps size_t from C.
+type SizeT C.size_t
+
+// This section contains a bunch of types that are basically just
+// unsafe.Pointer but have specific types to help "self document" what the
+// underlying pointer is really meant to represent.
+
+// CharPtrPtr is an unsafe pointer wrapping C's `char**`.
+type CharPtrPtr unsafe.Pointer
+
+// CharPtr is an unsafe pointer wrapping C's `char*`.
+type CharPtr unsafe.Pointer
+
+// SizeTPtr is an unsafe pointer wrapping C's `size_t*`.
+type SizeTPtr unsafe.Pointer
+
+// FreeFunc is a wrapper around calls to, or act like, C's free function.
+type FreeFunc func(unsafe.Pointer)

--- a/vendor/github.com/ceph/go-ceph/internal/errutil/strerror.go
+++ b/vendor/github.com/ceph/go-ceph/internal/errutil/strerror.go
@@ -1,0 +1,52 @@
+/*
+Package errutil provides common functions for dealing with error conditions for
+all ceph api wrappers.
+*/
+package errutil
+
+/* force XSI-complaint strerror_r() */
+
+// #define _POSIX_C_SOURCE 200112L
+// #undef _GNU_SOURCE
+// #include <stdlib.h>
+// #include <errno.h>
+// #include <string.h>
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+// FormatErrno returns the absolute value of the errno as well as a string
+// describing the errno. The string will be empty is the errno is not known.
+func FormatErrno(errno int) (int, string) {
+	buf := make([]byte, 1024)
+	// strerror expects errno >= 0
+	if errno < 0 {
+		errno = -errno
+	}
+
+	ret := C.strerror_r(
+		C.int(errno),
+		(*C.char)(unsafe.Pointer(&buf[0])),
+		C.size_t(len(buf)))
+	if ret != 0 {
+		return errno, ""
+	}
+
+	return errno, C.GoString((*C.char)(unsafe.Pointer(&buf[0])))
+}
+
+// FormatErrorCode returns a string that describes the supplied error source
+// and error code as a string. Suitable to use in Error() methods.  If the
+// error code maps to an errno the string will contain a description of the
+// error. Otherwise the string will only indicate the source and value if the
+// value does not map to a known errno.
+func FormatErrorCode(source string, errValue int) string {
+	_, s := FormatErrno(errValue)
+	if s == "" {
+		return fmt.Sprintf("%s: ret=%d", source, errValue)
+	}
+	return fmt.Sprintf("%s: ret=%d, %s", source, errValue, s)
+}

--- a/vendor/github.com/ceph/go-ceph/internal/errutil/strerror_test.go
+++ b/vendor/github.com/ceph/go-ceph/internal/errutil/strerror_test.go
@@ -1,0 +1,32 @@
+package errutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatError(t *testing.T) {
+	e, msg := FormatErrno(39)
+	assert.Equal(t, 39, e)
+	assert.Equal(t, msg, "Directory not empty")
+
+	e, msg = FormatErrno(-5)
+	assert.Equal(t, 5, e)
+	assert.Equal(t, msg, "Input/output error")
+
+	e, msg = FormatErrno(345)
+	assert.Equal(t, 345, e)
+	assert.Equal(t, msg, "")
+}
+
+func TestFormatErrorCode(t *testing.T) {
+	msg := FormatErrorCode("test", -39)
+	assert.Equal(t, msg, "test: ret=-39, Directory not empty")
+
+	msg = FormatErrorCode("test", -5)
+	assert.Equal(t, msg, "test: ret=-5, Input/output error")
+
+	msg = FormatErrorCode("boop", 345)
+	assert.Equal(t, msg, "boop: ret=345")
+}

--- a/vendor/github.com/ceph/go-ceph/internal/retry/example_sizer_test.go
+++ b/vendor/github.com/ceph/go-ceph/internal/retry/example_sizer_test.go
@@ -1,0 +1,56 @@
+package retry
+
+import (
+	"fmt"
+)
+
+var errTooSmall = fmt.Errorf("too small")
+
+func fakeComplexOp(v []string) error {
+	if len(v) < 30 {
+		fmt.Println("too small:", len(v))
+		return errTooSmall
+	}
+	fmt.Println("good size:", len(v))
+	return nil
+}
+
+func ExampleWithSizes() {
+	var err error
+	WithSizes(1, 128, func(size int) Hint {
+		buf := make([]string, size)
+		// do something complex with buf
+		err = fakeComplexOp(buf)
+		return DoubleSize.If(err == errTooSmall)
+	})
+	// Output:
+	// too small: 1
+	// too small: 2
+	// too small: 4
+	// too small: 8
+	// too small: 16
+	// good size: 32
+}
+
+func fakeComplexOp2(v []string, s *int) error {
+	if len(v) < 30 {
+		fmt.Println("too small:", len(v))
+		*s = 30
+		return errTooSmall
+	}
+	fmt.Println("good size:", len(v))
+	return nil
+}
+
+func ExampleWithSizes_hint() {
+	var err error
+	WithSizes(1, 128, func(size int) Hint {
+		buf := make([]string, size)
+		// do something complex with buf
+		err = fakeComplexOp2(buf, &size)
+		return Size(size).If(err == errTooSmall)
+	})
+	// Output:
+	// too small: 1
+	// good size: 30
+}

--- a/vendor/github.com/ceph/go-ceph/internal/retry/sizer.go
+++ b/vendor/github.com/ceph/go-ceph/internal/retry/sizer.go
@@ -1,0 +1,64 @@
+package retry
+
+// Hint is a type for retry hints
+type Hint interface {
+	If(bool) Hint
+	size() int
+}
+
+type hintInt int
+
+func (hint hintInt) size() int {
+	return int(hint)
+}
+
+// If is a convenience function, that returns a given hint only if a certain
+// condition is met (for example a test for a "buffer too small" error).
+// Otherwise it returns a nil which stops the retries.
+func (hint hintInt) If(cond bool) Hint {
+	if cond {
+		return hint
+	}
+	return nil
+}
+
+// DoubleSize is a hint to retry with double the size
+const DoubleSize = hintInt(0)
+
+// Size returns a hint for a specific size
+func Size(s int) Hint {
+	return hintInt(s)
+}
+
+// SizeFunc is used to implement 'resize loops' that hides the complexity of the
+// sizing away from most of the application. It's a function that takes a size
+// argument and returns nil, if no retry is necessary, or a hint indicating the
+// size for the next retry. If errors or other results are required from the
+// function, the function can write them to function closures of the surrounding
+// scope. See tests for examples.
+type SizeFunc func(size int) (hint Hint)
+
+// WithSizes repeatingly calls a SizeFunc with increasing sizes until either it
+// returns nil, or the max size has been reached. If the returned hint is
+// DoubleSize or indicating a size not greater than the current size, the size
+// is doubled. If the hint or next size is greater than the max size, the max
+// size is used for a last retry.
+func WithSizes(size int, max int, f SizeFunc) {
+	if size > max {
+		return
+	}
+	for {
+		hint := f(size)
+		if hint == nil || size == max {
+			break
+		}
+		if hint.size() > size {
+			size = hint.size()
+		} else {
+			size *= 2
+		}
+		if size > max {
+			size = max
+		}
+	}
+}

--- a/vendor/github.com/ceph/go-ceph/internal/retry/sizer_test.go
+++ b/vendor/github.com/ceph/go-ceph/internal/retry/sizer_test.go
@@ -1,0 +1,105 @@
+package retry
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSizer(t *testing.T) {
+	tooLong := errors.New("too long")
+
+	src := [][]byte{
+		[]byte("foobarbaz"),
+		[]byte("gondwandaland"),
+		[]byte("longer and longer still, not quite done"),
+		[]byte("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."),
+	}
+
+	// mimic a complex-ish data copy call
+	bcopy := func(src []byte, size int) ([]byte, error) {
+		if size < len(src) {
+			return nil, tooLong
+		}
+		dst := make([]byte, size)
+		copy(dst, src)
+		return dst, nil
+	}
+
+	for i, b := range src {
+		t.Run(fmt.Sprintf("bcopy_%d", i), func(t *testing.T) {
+			var out []byte
+			var err error
+			WithSizes(1, 4096, func(size int) Hint {
+				out, err = bcopy(b, size)
+				return DoubleSize.If(err == tooLong)
+			})
+			assert.Nil(t, err)
+			assert.Equal(t, b, out[:len(b)])
+		})
+	}
+
+	for i, b := range src {
+		t.Run(fmt.Sprintf("bcopy_hint_%d", i), func(t *testing.T) {
+			var tries int
+			var err error
+			var out []byte
+			WithSizes(1, 4096, func(size int) Hint {
+				tries++
+				out, err = bcopy(b, size)
+				return Size(len(b)).If(err == tooLong)
+			})
+			assert.Nil(t, err)
+			assert.Equal(t, b, out)
+			assert.Equal(t, 2, tries)
+		})
+	}
+
+	t.Run("exceedsMax", func(t *testing.T) {
+		var tries int
+		var err error
+		WithSizes(1, 1024, func(size int) Hint {
+			tries++
+			err = errors.New("foo")
+			return DoubleSize
+		})
+		assert.Error(t, err)
+		assert.Equal(t, 11, tries)
+	})
+
+	t.Run("hintExceedsMax", func(t *testing.T) {
+		var tries int
+		var lastSize int
+		WithSizes(1, 1024, func(size int) Hint {
+			tries++
+			lastSize = size
+			return Size(1025)
+		})
+		assert.Equal(t, 1024, lastSize)
+		assert.Equal(t, 2, tries)
+	})
+
+	t.Run("weirdSizeAndMax", func(t *testing.T) {
+		var tries int
+		var lastSize int
+		WithSizes(3, 1022, func(size int) Hint {
+			tries++
+			lastSize = size
+			return DoubleSize
+		})
+		assert.Equal(t, 10, tries)
+		assert.Equal(t, 1022, lastSize)
+	})
+
+	t.Run("sizeExceedsMax", func(t *testing.T) {
+		var lastSize int
+		WithSizes(1023, 1022, func(size int) Hint {
+			lastSize = size
+			return DoubleSize
+		})
+		assert.Equal(t, 0, lastSize)
+	})
+
+}

--- a/vendor/github.com/ceph/go-ceph/internal/timespec/timespec.go
+++ b/vendor/github.com/ceph/go-ceph/internal/timespec/timespec.go
@@ -1,0 +1,30 @@
+package timespec
+
+/*
+#include <time.h>
+*/
+import "C"
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// Timespec behaves similarly to C's struct timespec.
+// Timespec is used to retain fidelity to the C based file systems
+// apis that could be lossy with the use of Go time types.
+type Timespec unix.Timespec
+
+// CTimespecPtr is an unsafe pointer wrapping C's `struct timespec`.
+type CTimespecPtr unsafe.Pointer
+
+// CStructToTimespec creates a new Timespec for the C 'struct timespec'.
+func CStructToTimespec(cts CTimespecPtr) Timespec {
+	t := (*C.struct_timespec)(cts)
+
+	return Timespec{
+		Sec:  int64(t.tv_sec),
+		Nsec: int64(t.tv_nsec),
+	}
+}

--- a/vendor/github.com/ceph/go-ceph/rados/command.go
+++ b/vendor/github.com/ceph/go-ceph/rados/command.go
@@ -1,0 +1,193 @@
+package rados
+
+// #cgo LDFLAGS: -lrados
+// #include <stdlib.h>
+// #include <rados/librados.h>
+import "C"
+
+import (
+	"unsafe"
+
+	"github.com/ceph/go-ceph/internal/cutil"
+)
+
+func radosBufferFree(p unsafe.Pointer) {
+	C.rados_buffer_free((*C.char)(p))
+}
+
+// MonCommand sends a command to one of the monitors
+func (c *Conn) MonCommand(args []byte) ([]byte, string, error) {
+	return c.MonCommandWithInputBuffer(args, nil)
+}
+
+// MonCommandWithInputBuffer sends a command to one of the monitors, with an input buffer
+func (c *Conn) MonCommandWithInputBuffer(args, inputBuffer []byte) ([]byte, string, error) {
+	ci := cutil.NewCommandInput([][]byte{args}, inputBuffer)
+	defer ci.Free()
+	co := cutil.NewCommandOutput().SetFreeFunc(radosBufferFree)
+	defer co.Free()
+
+	ret := C.rados_mon_command(
+		c.cluster,
+		(**C.char)(ci.Cmd()),
+		C.size_t(ci.CmdLen()),
+		(*C.char)(ci.InBuf()),
+		C.size_t(ci.InBufLen()),
+		(**C.char)(co.OutBuf()),
+		(*C.size_t)(co.OutBufLen()),
+		(**C.char)(co.Outs()),
+		(*C.size_t)(co.OutsLen()))
+	buf, status := co.GoValues()
+	return buf, status, getError(ret)
+}
+
+// PGCommand sends a command to one of the PGs
+//
+// Implements:
+//  int rados_pg_command(rados_t cluster, const char *pgstr,
+//                       const char **cmd, size_t cmdlen,
+//                       const char *inbuf, size_t inbuflen,
+//                       char **outbuf, size_t *outbuflen,
+//                       char **outs, size_t *outslen);
+func (c *Conn) PGCommand(pgid []byte, args [][]byte) ([]byte, string, error) {
+	return c.PGCommandWithInputBuffer(pgid, args, nil)
+}
+
+// PGCommandWithInputBuffer sends a command to one of the PGs, with an input buffer
+//
+// Implements:
+//  int rados_pg_command(rados_t cluster, const char *pgstr,
+//                       const char **cmd, size_t cmdlen,
+//                       const char *inbuf, size_t inbuflen,
+//                       char **outbuf, size_t *outbuflen,
+//                       char **outs, size_t *outslen);
+func (c *Conn) PGCommandWithInputBuffer(pgid []byte, args [][]byte, inputBuffer []byte) ([]byte, string, error) {
+	name := C.CString(string(pgid))
+	defer C.free(unsafe.Pointer(name))
+	ci := cutil.NewCommandInput(args, inputBuffer)
+	defer ci.Free()
+	co := cutil.NewCommandOutput().SetFreeFunc(radosBufferFree)
+	defer co.Free()
+
+	ret := C.rados_pg_command(
+		c.cluster,
+		name,
+		(**C.char)(ci.Cmd()),
+		C.size_t(ci.CmdLen()),
+		(*C.char)(ci.InBuf()),
+		C.size_t(ci.InBufLen()),
+		(**C.char)(co.OutBuf()),
+		(*C.size_t)(co.OutBufLen()),
+		(**C.char)(co.Outs()),
+		(*C.size_t)(co.OutsLen()))
+	buf, status := co.GoValues()
+	return buf, status, getError(ret)
+}
+
+// MgrCommand sends a command to a ceph-mgr.
+func (c *Conn) MgrCommand(args [][]byte) ([]byte, string, error) {
+	return c.MgrCommandWithInputBuffer(args, nil)
+}
+
+// MgrCommandWithInputBuffer sends a command, with an input buffer, to a ceph-mgr.
+//
+// Implements:
+//  int rados_mgr_command(rados_t cluster, const char **cmd,
+//                         size_t cmdlen, const char *inbuf,
+//                         size_t inbuflen, char **outbuf,
+//                         size_t *outbuflen, char **outs,
+//                          size_t *outslen);
+func (c *Conn) MgrCommandWithInputBuffer(args [][]byte, inputBuffer []byte) ([]byte, string, error) {
+	ci := cutil.NewCommandInput(args, inputBuffer)
+	defer ci.Free()
+	co := cutil.NewCommandOutput().SetFreeFunc(radosBufferFree)
+	defer co.Free()
+
+	ret := C.rados_mgr_command(
+		c.cluster,
+		(**C.char)(ci.Cmd()),
+		C.size_t(ci.CmdLen()),
+		(*C.char)(ci.InBuf()),
+		C.size_t(ci.InBufLen()),
+		(**C.char)(co.OutBuf()),
+		(*C.size_t)(co.OutBufLen()),
+		(**C.char)(co.Outs()),
+		(*C.size_t)(co.OutsLen()))
+	buf, status := co.GoValues()
+	return buf, status, getError(ret)
+}
+
+// OsdCommand sends a command to the specified ceph OSD.
+func (c *Conn) OsdCommand(osd int, args [][]byte) ([]byte, string, error) {
+	return c.OsdCommandWithInputBuffer(osd, args, nil)
+}
+
+// OsdCommandWithInputBuffer sends a command, with an input buffer, to the
+// specified ceph OSD.
+//
+// Implements:
+//  int rados_osd_command(rados_t cluster, int osdid,
+//                                       const char **cmd, size_t cmdlen,
+//                                       const char *inbuf, size_t inbuflen,
+//                                       char **outbuf, size_t *outbuflen,
+//                                       char **outs, size_t *outslen);
+func (c *Conn) OsdCommandWithInputBuffer(
+	osd int, args [][]byte, inputBuffer []byte) ([]byte, string, error) {
+
+	ci := cutil.NewCommandInput(args, inputBuffer)
+	defer ci.Free()
+	co := cutil.NewCommandOutput().SetFreeFunc(radosBufferFree)
+	defer co.Free()
+
+	ret := C.rados_osd_command(
+		c.cluster,
+		C.int(osd),
+		(**C.char)(ci.Cmd()),
+		C.size_t(ci.CmdLen()),
+		(*C.char)(ci.InBuf()),
+		C.size_t(ci.InBufLen()),
+		(**C.char)(co.OutBuf()),
+		(*C.size_t)(co.OutBufLen()),
+		(**C.char)(co.Outs()),
+		(*C.size_t)(co.OutsLen()))
+	buf, status := co.GoValues()
+	return buf, status, getError(ret)
+}
+
+// MonCommandTarget sends a command to a specified monitor.
+func (c *Conn) MonCommandTarget(name string, args [][]byte) ([]byte, string, error) {
+	return c.MonCommandTargetWithInputBuffer(name, args, nil)
+}
+
+// MonCommandTargetWithInputBuffer sends a command, with an input buffer, to a specified monitor.
+//
+// Implements:
+//  int rados_mon_command_target(rados_t cluster, const char *name,
+//                               const char **cmd, size_t cmdlen,
+//                               const char *inbuf, size_t inbuflen,
+//                               char **outbuf, size_t *outbuflen,
+//                               char **outs, size_t *outslen);
+func (c *Conn) MonCommandTargetWithInputBuffer(
+	name string, args [][]byte, inputBuffer []byte) ([]byte, string, error) {
+
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	ci := cutil.NewCommandInput(args, inputBuffer)
+	defer ci.Free()
+	co := cutil.NewCommandOutput().SetFreeFunc(radosBufferFree)
+	defer co.Free()
+
+	ret := C.rados_mon_command_target(
+		c.cluster,
+		cName,
+		(**C.char)(ci.Cmd()),
+		C.size_t(ci.CmdLen()),
+		(*C.char)(ci.InBuf()),
+		C.size_t(ci.InBufLen()),
+		(**C.char)(co.OutBuf()),
+		(*C.size_t)(co.OutBufLen()),
+		(**C.char)(co.Outs()),
+		(*C.size_t)(co.OutsLen()))
+	buf, status := co.GoValues()
+	return buf, status, getError(ret)
+}

--- a/vendor/github.com/ceph/go-ceph/rados/command_mimic_test.go
+++ b/vendor/github.com/ceph/go-ceph/rados/command_mimic_test.go
@@ -1,0 +1,37 @@
+// +build !luminous
+
+package rados
+
+import (
+	"encoding/json"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// A real test using input buffer is hard to find for mgr.
+// The simplest does not work on luminous, so we simply don't
+// provide the test for luminous.
+
+func (suite *RadosTestSuite) TestMgrCommandWithInputBuffer() {
+	suite.SetupConnection()
+
+	command, err := json.Marshal(
+		map[string]string{"prefix": "crash post", "format": "json"})
+	assert.NoError(suite.T(), err)
+
+	buf, info, err := suite.conn.MgrCommandWithInputBuffer(
+		[][]byte{command}, []byte(`{"crash_id": "foobar", "timestamp": "2020-04-10 15:08:34.659679Z"}`))
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), info, "")
+	assert.Len(suite.T(), buf, 0)
+
+	command, err = json.Marshal(
+		map[string]string{"prefix": "crash rm", "id": "foobar", "format": "json"})
+	assert.NoError(suite.T(), err)
+
+	buf, info, err = suite.conn.MgrCommandWithInputBuffer(
+		[][]byte{command}, nil)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), info, "")
+	assert.Len(suite.T(), buf, 0)
+}

--- a/vendor/github.com/ceph/go-ceph/rados/command_test.go
+++ b/vendor/github.com/ceph/go-ceph/rados/command_test.go
@@ -1,0 +1,220 @@
+package rados
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	osdNumber = 0
+	monName   = "a"
+)
+
+func (suite *RadosTestSuite) TestMonCommand() {
+	suite.SetupConnection()
+
+	command, err := json.Marshal(
+		map[string]string{"prefix": "df", "format": "json"})
+	assert.NoError(suite.T(), err)
+
+	buf, info, err := suite.conn.MonCommand(command)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), info, "")
+
+	var message map[string]interface{}
+	err = json.Unmarshal(buf, &message)
+	assert.NoError(suite.T(), err)
+}
+
+// NB: ceph octopus appears to be stricter about the formatting of the keyring
+// and now rejects whitespace that older versions did not have a problem with.
+const clientKeyFormat = `
+[%s]
+key = AQD4PGNXBZJNHhAA582iUgxe9DsN+MqFN4Z6Jw==
+`
+
+func (suite *RadosTestSuite) TestMonCommandWithInputBuffer() {
+	suite.SetupConnection()
+
+	entity := fmt.Sprintf("client.testMonCmdUser%d", time.Now().UnixNano())
+
+	// first add the new test user, specifying its key in the input buffer
+	command, err := json.Marshal(map[string]interface{}{
+		"prefix": "auth add",
+		"format": "json",
+		"entity": entity,
+	})
+	assert.NoError(suite.T(), err)
+
+	client_key := fmt.Sprintf(clientKeyFormat, entity)
+
+	inbuf := []byte(client_key)
+
+	buf, info, err := suite.conn.MonCommandWithInputBuffer(command, inbuf)
+	assert.NoError(suite.T(), err)
+	expected_info := fmt.Sprintf("added key for %s", entity)
+	assert.Equal(suite.T(), expected_info, info)
+	assert.Equal(suite.T(), "", string(buf[:]))
+
+	// get the key and verify that it's what we previously set
+	command, err = json.Marshal(map[string]interface{}{
+		"prefix": "auth get-key",
+		"format": "json",
+		"entity": entity,
+	})
+	assert.NoError(suite.T(), err)
+
+	buf, info, err = suite.conn.MonCommand(command)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "", info)
+	assert.Equal(suite.T(),
+		`{"key":"AQD4PGNXBZJNHhAA582iUgxe9DsN+MqFN4Z6Jw=="}`,
+		string(buf[:]))
+}
+
+func (suite *RadosTestSuite) TestPGCommand() {
+	suite.SetupConnection()
+
+	pgid := "1.2"
+
+	command, err := json.Marshal(
+		map[string]string{"prefix": "query", "pgid": pgid, "format": "json"})
+	assert.NoError(suite.T(), err)
+
+	buf, info, err := suite.conn.PGCommand([]byte(pgid), [][]byte{[]byte(command)})
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), info, "")
+
+	var message map[string]interface{}
+	err = json.Unmarshal(buf, &message)
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *RadosTestSuite) TestMgrCommandDescriptions() {
+	suite.SetupConnection()
+
+	command, err := json.Marshal(
+		map[string]string{"prefix": "get_command_descriptions", "format": "json"})
+	assert.NoError(suite.T(), err)
+
+	buf, info, err := suite.conn.MgrCommand([][]byte{command})
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), info, "")
+
+	var message map[string]interface{}
+	err = json.Unmarshal(buf, &message)
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *RadosTestSuite) TestMgrCommand() {
+	suite.SetupConnection()
+
+	command, err := json.Marshal(
+		map[string]string{"prefix": "balancer status", "format": "json"})
+	assert.NoError(suite.T(), err)
+
+	buf, info, err := suite.conn.MgrCommand([][]byte{command})
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), info, "")
+
+	var message map[string]interface{}
+	err = json.Unmarshal(buf, &message)
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *RadosTestSuite) TestMgrCommandMalformedCommand() {
+	suite.SetupConnection()
+
+	command := []byte("JUNK!")
+	buf, info, err := suite.conn.MgrCommand([][]byte{command})
+	assert.Error(suite.T(), err)
+	assert.NotEqual(suite.T(), info, "")
+	assert.Len(suite.T(), buf, 0)
+}
+
+func (suite *RadosTestSuite) TestOsdCommandDescriptions() {
+	suite.SetupConnection()
+
+	command, err := json.Marshal(
+		map[string]string{"prefix": "get_command_descriptions", "format": "json"})
+	assert.NoError(suite.T(), err)
+
+	buf, info, err := suite.conn.OsdCommand(osdNumber, [][]byte{command})
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), info, "")
+
+	var message map[string]interface{}
+	err = json.Unmarshal(buf, &message)
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *RadosTestSuite) TestOsdCommand() {
+	suite.SetupConnection()
+
+	command, err := json.Marshal(
+		map[string]string{"prefix": "version", "format": "json"})
+	assert.NoError(suite.T(), err)
+
+	buf, info, err := suite.conn.OsdCommand(osdNumber, [][]byte{command})
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), info, "")
+
+	var message map[string]interface{}
+	err = json.Unmarshal(buf, &message)
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *RadosTestSuite) TestOsdCommandMalformedCommand() {
+	suite.SetupConnection()
+
+	command := []byte("JUNK!")
+	buf, info, err := suite.conn.OsdCommand(osdNumber, [][]byte{command})
+	assert.Error(suite.T(), err)
+	assert.NotEqual(suite.T(), info, "")
+	assert.Len(suite.T(), buf, 0)
+}
+
+func (suite *RadosTestSuite) TestMonCommandTargetDescriptions() {
+	suite.SetupConnection()
+
+	command, err := json.Marshal(
+		map[string]string{"prefix": "get_command_descriptions", "format": "json"})
+	assert.NoError(suite.T(), err)
+
+	buf, info, err := suite.conn.MonCommandTarget(monName, [][]byte{command})
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), info, "")
+
+	var message map[string]interface{}
+	err = json.Unmarshal(buf, &message)
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *RadosTestSuite) TestMonCommandTarget() {
+	suite.SetupConnection()
+
+	command, err := json.Marshal(
+		map[string]string{"prefix": "mon_status"})
+	assert.NoError(suite.T(), err)
+
+	buf, info, err := suite.conn.MonCommandTarget(monName, [][]byte{command})
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), info, "")
+
+	var message map[string]interface{}
+	err = json.Unmarshal(buf, &message)
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *RadosTestSuite) TestMonCommandTargetMalformedCommand() {
+	suite.SetupConnection()
+
+	command := []byte("JUNK!")
+	buf, info, err := suite.conn.MonCommandTarget(monName, [][]byte{command})
+	assert.Error(suite.T(), err)
+	assert.NotEqual(suite.T(), info, "")
+	assert.Len(suite.T(), buf, 0)
+}

--- a/vendor/github.com/ceph/go-ceph/rados/doc.go
+++ b/vendor/github.com/ceph/go-ceph/rados/doc.go
@@ -1,4 +1,4 @@
 /*
-Set of wrappers around librados API.
+Package rados contains a set of wrappers around Ceph's librados API.
 */
 package rados

--- a/vendor/github.com/ceph/go-ceph/rados/errors.go
+++ b/vendor/github.com/ceph/go-ceph/rados/errors.go
@@ -1,0 +1,83 @@
+package rados
+
+/*
+#include <errno.h>
+*/
+import "C"
+
+import (
+	"errors"
+
+	"github.com/ceph/go-ceph/internal/errutil"
+)
+
+// radosError represents an error condition returned from the Ceph RADOS APIs.
+type radosError int
+
+// Error returns the error string for the radosError type.
+func (e radosError) Error() string {
+	return errutil.FormatErrorCode("rados", int(e))
+}
+
+func (e radosError) ErrorCode() int {
+	return int(e)
+}
+
+func getError(e C.int) error {
+	if e == 0 {
+		return nil
+	}
+	return radosError(e)
+}
+
+// getErrorIfNegative converts a ceph return code to error if negative.
+// This is useful for functions that return a usable positive value on
+// success but a negative error number on error.
+func getErrorIfNegative(ret C.int) error {
+	if ret >= 0 {
+		return nil
+	}
+	return getError(ret)
+}
+
+// Public go errors:
+
+var (
+	// ErrNotConnected is returned when functions are called
+	// without a RADOS connection.
+	ErrNotConnected = errors.New("RADOS not connected")
+	// ErrEmptyArgument may be returned if a function argument is passed
+	// a zero-length slice or map.
+	ErrEmptyArgument = errors.New("Argument must contain at least one item")
+	// ErrInvalidIOContext may be returned if an api call requires an IOContext
+	// but IOContext is not ready for use.
+	ErrInvalidIOContext = errors.New("IOContext is not ready for use")
+)
+
+// Public radosErrors:
+
+const (
+	// ErrNotFound indicates a missing resource.
+	ErrNotFound = radosError(-C.ENOENT)
+	// ErrPermissionDenied indicates a permissions issue.
+	ErrPermissionDenied = radosError(-C.EPERM)
+	// ErrObjectExists indicates that an exclusive object creation failed.
+	ErrObjectExists = radosError(-C.EEXIST)
+
+	// RadosErrorNotFound indicates a missing resource.
+	//
+	// Deprecated: use ErrNotFound instead
+	RadosErrorNotFound = ErrNotFound
+	// RadosErrorPermissionDenied indicates a permissions issue.
+	//
+	// Deprecated: use ErrPermissionDenied instead
+	RadosErrorPermissionDenied = ErrPermissionDenied
+)
+
+// Private errors:
+
+const (
+	errNameTooLong = radosError(-C.ENAMETOOLONG)
+
+	errRange = radosError(-C.ERANGE)
+)

--- a/vendor/github.com/ceph/go-ceph/rados/errors_test.go
+++ b/vendor/github.com/ceph/go-ceph/rados/errors_test.go
@@ -1,0 +1,26 @@
+package rados
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRadosError(t *testing.T) {
+	err := getError(0)
+	assert.NoError(t, err)
+
+	err = getError(-5) // IO error
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), "rados: ret=-5, Input/output error")
+
+	errno, ok := err.(interface{ ErrorCode() int })
+	assert.True(t, ok)
+	require.NotNil(t, errno)
+	assert.Equal(t, errno.ErrorCode(), -5)
+
+	err = getError(345) // no such errno
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), "rados: ret=345")
+}

--- a/vendor/github.com/ceph/go-ceph/rados/ioctx.go
+++ b/vendor/github.com/ceph/go-ceph/rados/ioctx.go
@@ -28,6 +28,21 @@ import (
 	"syscall"
 	"time"
 	"unsafe"
+
+	"github.com/ceph/go-ceph/internal/retry"
+)
+
+// CreateOption is passed to IOContext.Create() and should be one of
+// CreateExclusive or CreateIdempotent.
+type CreateOption int
+
+const (
+	// CreateExclusive if used with IOContext.Create() and the object
+	// already exists, the function will return an error.
+	CreateExclusive = C.LIBRADOS_CREATE_EXCLUSIVE
+	// CreateIdempotent if used with IOContext.Create() and the object
+	// already exists, the function will not return an error.
+	CreateIdempotent = C.LIBRADOS_CREATE_IDEMPOTENT
 )
 
 // PoolStat represents Ceph pool statistics.
@@ -77,9 +92,19 @@ type IOContext struct {
 	ioctx C.rados_ioctx_t
 }
 
-// Pointer returns a uintptr representation of the IOContext.
-func (ioctx *IOContext) Pointer() uintptr {
-	return uintptr(ioctx.ioctx)
+// validate returns an error if the ioctx is not ready to be used
+// with ceph C calls.
+func (ioctx *IOContext) validate() error {
+	if ioctx.ioctx == nil {
+		return ErrInvalidIOContext
+	}
+	return nil
+}
+
+// Pointer returns a pointer reference to an internal structure.
+// This function should NOT be used outside of go-ceph itself.
+func (ioctx *IOContext) Pointer() unsafe.Pointer {
+	return unsafe.Pointer(ioctx.ioctx)
 }
 
 // SetNamespace sets the namespace for objects within this IO context (pool).
@@ -91,6 +116,23 @@ func (ioctx *IOContext) SetNamespace(namespace string) {
 		defer C.free(unsafe.Pointer(c_ns))
 	}
 	C.rados_ioctx_set_namespace(ioctx.ioctx, c_ns)
+}
+
+// Create a new object with key oid.
+//
+// Implements:
+//  void rados_write_op_create(rados_write_op_t write_op, int exclusive,
+//                             const char* category)
+func (ioctx *IOContext) Create(oid string, exclusive CreateOption) error {
+	c_oid := C.CString(oid)
+	defer C.free(unsafe.Pointer(c_oid))
+
+	op := C.rados_create_write_op()
+	C.rados_write_op_create(op, C.int(exclusive), nil)
+	ret := C.rados_write_op_operate(op, ioctx.ioctx, c_oid, nil, 0)
+	C.rados_release_write_op(op)
+
+	return getError(ret)
 }
 
 // Write writes len(data) bytes to the object with key oid starting at byte
@@ -109,7 +151,7 @@ func (ioctx *IOContext) Write(oid string, data []byte, offset uint64) error {
 		(C.size_t)(len(data)),
 		(C.uint64_t)(offset))
 
-	return GetRadosError(int(ret))
+	return getError(ret)
 }
 
 // WriteFull writes len(data) bytes to the object with key oid.
@@ -122,7 +164,7 @@ func (ioctx *IOContext) WriteFull(oid string, data []byte) error {
 	ret := C.rados_write_full(ioctx.ioctx, c_oid,
 		(*C.char)(unsafe.Pointer(&data[0])),
 		(C.size_t)(len(data)))
-	return GetRadosError(int(ret))
+	return getError(ret)
 }
 
 // Append appends len(data) bytes to the object with key oid.
@@ -135,7 +177,7 @@ func (ioctx *IOContext) Append(oid string, data []byte) error {
 	ret := C.rados_append(ioctx.ioctx, c_oid,
 		(*C.char)(unsafe.Pointer(&data[0])),
 		(C.size_t)(len(data)))
-	return GetRadosError(int(ret))
+	return getError(ret)
 }
 
 // Read reads up to len(data) bytes from the object with key oid starting at byte
@@ -158,9 +200,8 @@ func (ioctx *IOContext) Read(oid string, data []byte, offset uint64) (int, error
 
 	if ret >= 0 {
 		return int(ret), nil
-	} else {
-		return 0, GetRadosError(int(ret))
 	}
+	return 0, getError(ret)
 }
 
 // Delete deletes the object with key oid. It returns an error, if any.
@@ -168,7 +209,7 @@ func (ioctx *IOContext) Delete(oid string) error {
 	c_oid := C.CString(oid)
 	defer C.free(unsafe.Pointer(c_oid))
 
-	return GetRadosError(int(C.rados_remove(ioctx.ioctx, c_oid)))
+	return getError(C.rados_remove(ioctx.ioctx, c_oid))
 }
 
 // Truncate resizes the object with key oid to size size. If the operation
@@ -179,7 +220,7 @@ func (ioctx *IOContext) Truncate(oid string, size uint64) error {
 	c_oid := C.CString(oid)
 	defer C.free(unsafe.Pointer(c_oid))
 
-	return GetRadosError(int(C.rados_trunc(ioctx.ioctx, c_oid, (C.uint64_t)(size))))
+	return getError(C.rados_trunc(ioctx.ioctx, c_oid, (C.uint64_t)(size)))
 }
 
 // Destroy informs librados that the I/O context is no longer in use.
@@ -189,46 +230,63 @@ func (ioctx *IOContext) Destroy() {
 	C.rados_ioctx_destroy(ioctx.ioctx)
 }
 
-// Stat returns a set of statistics about the pool associated with this I/O
+// GetPoolStats returns a set of statistics about the pool associated with this I/O
 // context.
+//
+// Implements:
+//  int rados_ioctx_pool_stat(rados_ioctx_t io,
+//                            struct rados_pool_stat_t *stats);
 func (ioctx *IOContext) GetPoolStats() (stat PoolStat, err error) {
 	c_stat := C.struct_rados_pool_stat_t{}
 	ret := C.rados_ioctx_pool_stat(ioctx.ioctx, &c_stat)
 	if ret < 0 {
-		return PoolStat{}, GetRadosError(int(ret))
-	} else {
-		return PoolStat{
-			Num_bytes:                      uint64(c_stat.num_bytes),
-			Num_kb:                         uint64(c_stat.num_kb),
-			Num_objects:                    uint64(c_stat.num_objects),
-			Num_object_clones:              uint64(c_stat.num_object_clones),
-			Num_object_copies:              uint64(c_stat.num_object_copies),
-			Num_objects_missing_on_primary: uint64(c_stat.num_objects_missing_on_primary),
-			Num_objects_unfound:            uint64(c_stat.num_objects_unfound),
-			Num_objects_degraded:           uint64(c_stat.num_objects_degraded),
-			Num_rd:                         uint64(c_stat.num_rd),
-			Num_rd_kb:                      uint64(c_stat.num_rd_kb),
-			Num_wr:                         uint64(c_stat.num_wr),
-			Num_wr_kb:                      uint64(c_stat.num_wr_kb),
-		}, nil
+		return PoolStat{}, getError(ret)
 	}
+	return PoolStat{
+		Num_bytes:                      uint64(c_stat.num_bytes),
+		Num_kb:                         uint64(c_stat.num_kb),
+		Num_objects:                    uint64(c_stat.num_objects),
+		Num_object_clones:              uint64(c_stat.num_object_clones),
+		Num_object_copies:              uint64(c_stat.num_object_copies),
+		Num_objects_missing_on_primary: uint64(c_stat.num_objects_missing_on_primary),
+		Num_objects_unfound:            uint64(c_stat.num_objects_unfound),
+		Num_objects_degraded:           uint64(c_stat.num_objects_degraded),
+		Num_rd:                         uint64(c_stat.num_rd),
+		Num_rd_kb:                      uint64(c_stat.num_rd_kb),
+		Num_wr:                         uint64(c_stat.num_wr),
+		Num_wr_kb:                      uint64(c_stat.num_wr_kb),
+	}, nil
+}
+
+// GetPoolID returns the pool ID associated with the I/O context.
+//
+// Implements:
+//  int64_t rados_ioctx_get_id(rados_ioctx_t io)
+func (ioctx *IOContext) GetPoolID() int64 {
+	ret := C.rados_ioctx_get_id(ioctx.ioctx)
+	return int64(ret)
 }
 
 // GetPoolName returns the name of the pool associated with the I/O context.
 func (ioctx *IOContext) GetPoolName() (name string, err error) {
-	buf := make([]byte, 128)
-	for {
-		ret := C.rados_ioctx_get_pool_name(ioctx.ioctx,
-			(*C.char)(unsafe.Pointer(&buf[0])), C.unsigned(len(buf)))
-		if ret == -C.ERANGE {
-			buf = make([]byte, len(buf)*2)
-			continue
-		} else if ret < 0 {
-			return "", GetRadosError(int(ret))
-		}
-		name = C.GoStringN((*C.char)(unsafe.Pointer(&buf[0])), ret)
-		return name, nil
+	var (
+		buf []byte
+		ret C.int
+	)
+	retry.WithSizes(128, 8192, func(size int) retry.Hint {
+		buf = make([]byte, size)
+		ret = C.rados_ioctx_get_pool_name(
+			ioctx.ioctx,
+			(*C.char)(unsafe.Pointer(&buf[0])),
+			C.unsigned(len(buf)))
+		err = getErrorIfNegative(ret)
+		return retry.DoubleSize.If(err == errRange)
+	})
+	if err != nil {
+		return "", err
 	}
+	name = C.GoStringN((*C.char)(unsafe.Pointer(&buf[0])), ret)
+	return name, nil
 }
 
 // ObjectListFunc is the type of the function called for each object visited
@@ -244,7 +302,7 @@ func (ioctx *IOContext) ListObjects(listFn ObjectListFunc) error {
 	var ctx C.rados_list_ctx_t
 	ret := C.rados_nobjects_list_open(ioctx.ioctx, &ctx)
 	if ret < 0 {
-		return GetRadosError(int(ret))
+		return getError(ret)
 	}
 	defer func() { C.rados_nobjects_list_close(ctx) }()
 
@@ -254,7 +312,7 @@ func (ioctx *IOContext) ListObjects(listFn ObjectListFunc) error {
 		if ret == -C.ENOENT {
 			return nil
 		} else if ret < 0 {
-			return GetRadosError(int(ret))
+			return getError(ret)
 		}
 		listFn(C.GoString(c_entry))
 	}
@@ -274,13 +332,12 @@ func (ioctx *IOContext) Stat(object string) (stat ObjectStat, err error) {
 		&c_pmtime)
 
 	if ret < 0 {
-		return ObjectStat{}, GetRadosError(int(ret))
-	} else {
-		return ObjectStat{
-			Size:    uint64(c_psize),
-			ModTime: time.Unix(int64(c_pmtime), 0),
-		}, nil
+		return ObjectStat{}, getError(ret)
 	}
+	return ObjectStat{
+		Size:    uint64(c_psize),
+		ModTime: time.Unix(int64(c_pmtime), 0),
+	}, nil
 }
 
 // GetXattr gets an xattr with key `name`, it returns the length of
@@ -300,12 +357,11 @@ func (ioctx *IOContext) GetXattr(object string, name string, data []byte) (int, 
 
 	if ret >= 0 {
 		return int(ret), nil
-	} else {
-		return 0, GetRadosError(int(ret))
 	}
+	return 0, getError(ret)
 }
 
-// Sets an xattr for an object with key `name` with value as `data`
+// SetXattr sets an xattr for an object with key `name` with value as `data`
 func (ioctx *IOContext) SetXattr(object string, name string, data []byte) error {
 	c_object := C.CString(object)
 	c_name := C.CString(name)
@@ -319,12 +375,11 @@ func (ioctx *IOContext) SetXattr(object string, name string, data []byte) error 
 		(*C.char)(unsafe.Pointer(&data[0])),
 		(C.size_t)(len(data)))
 
-	return GetRadosError(int(ret))
+	return getError(ret)
 }
 
-// function that lists all the xattrs for an object, since xattrs are
-// a k-v pair, this function returns a map of k-v pairs on
-// success, error code on failure
+// ListXattrs lists all the xattrs for an object. The xattrs are returned as a
+// mapping of string keys and byte-slice values.
 func (ioctx *IOContext) ListXattrs(oid string) (map[string][]byte, error) {
 	c_oid := C.CString(oid)
 	defer C.free(unsafe.Pointer(c_oid))
@@ -333,7 +388,7 @@ func (ioctx *IOContext) ListXattrs(oid string) (map[string][]byte, error) {
 
 	ret := C.rados_getxattrs(ioctx.ioctx, c_oid, &it)
 	if ret < 0 {
-		return nil, GetRadosError(int(ret))
+		return nil, getError(ret)
 	}
 	defer func() { C.rados_getxattrs_end(it) }()
 	m := make(map[string][]byte)
@@ -345,7 +400,7 @@ func (ioctx *IOContext) ListXattrs(oid string) (map[string][]byte, error) {
 
 		ret := C.rados_getxattrs_next(it, &c_name, &c_val, &c_len)
 		if ret < 0 {
-			return nil, GetRadosError(int(ret))
+			return nil, getError(ret)
 		}
 		// rados api returns a null name,val & 0-length upon
 		// end of iteration
@@ -356,7 +411,7 @@ func (ioctx *IOContext) ListXattrs(oid string) (map[string][]byte, error) {
 	}
 }
 
-// Remove an xattr with key `name` from object `oid`
+// RmXattr removes an xattr with key `name` from object `oid`
 func (ioctx *IOContext) RmXattr(oid string, name string) error {
 	c_oid := C.CString(oid)
 	c_name := C.CString(name)
@@ -368,308 +423,10 @@ func (ioctx *IOContext) RmXattr(oid string, name string) error {
 		c_oid,
 		c_name)
 
-	return GetRadosError(int(ret))
+	return getError(ret)
 }
 
-// Append the map `pairs` to the omap `oid`
-func (ioctx *IOContext) SetOmap(oid string, pairs map[string][]byte) error {
-	c_oid := C.CString(oid)
-	defer C.free(unsafe.Pointer(c_oid))
-
-	var s C.size_t
-	var c *C.char
-	ptrSize := unsafe.Sizeof(c)
-
-	c_keys := C.malloc(C.size_t(len(pairs)) * C.size_t(ptrSize))
-	c_values := C.malloc(C.size_t(len(pairs)) * C.size_t(ptrSize))
-	c_lengths := C.malloc(C.size_t(len(pairs)) * C.size_t(unsafe.Sizeof(s)))
-
-	defer C.free(unsafe.Pointer(c_keys))
-	defer C.free(unsafe.Pointer(c_values))
-	defer C.free(unsafe.Pointer(c_lengths))
-
-	i := 0
-	for key, value := range pairs {
-		// key
-		c_key_ptr := (**C.char)(unsafe.Pointer(uintptr(c_keys) + uintptr(i)*ptrSize))
-		*c_key_ptr = C.CString(key)
-		defer C.free(unsafe.Pointer(*c_key_ptr))
-
-		// value and its length
-		c_value_ptr := (**C.char)(unsafe.Pointer(uintptr(c_values) + uintptr(i)*ptrSize))
-
-		var c_length C.size_t
-		if len(value) > 0 {
-			*c_value_ptr = (*C.char)(unsafe.Pointer(&value[0]))
-			c_length = C.size_t(len(value))
-		} else {
-			*c_value_ptr = nil
-			c_length = C.size_t(0)
-		}
-
-		c_length_ptr := (*C.size_t)(unsafe.Pointer(uintptr(c_lengths) + uintptr(i)*ptrSize))
-		*c_length_ptr = c_length
-
-		i++
-	}
-
-	op := C.rados_create_write_op()
-	C.rados_write_op_omap_set(
-		op,
-		(**C.char)(c_keys),
-		(**C.char)(c_values),
-		(*C.size_t)(c_lengths),
-		C.size_t(len(pairs)))
-
-	ret := C.rados_write_op_operate(op, ioctx.ioctx, c_oid, nil, 0)
-	C.rados_release_write_op(op)
-
-	return GetRadosError(int(ret))
-}
-
-// OmapListFunc is the type of the function called for each omap key
-// visited by ListOmapValues
-type OmapListFunc func(key string, value []byte)
-
-// Iterate on a set of keys and their values from an omap
-// `startAfter`: iterate only on the keys after this specified one
-// `filterPrefix`: iterate only on the keys beginning with this prefix
-// `maxReturn`: iterate no more than `maxReturn` key/value pairs
-// `listFn`: the function called at each iteration
-func (ioctx *IOContext) ListOmapValues(oid string, startAfter string, filterPrefix string, maxReturn int64, listFn OmapListFunc) error {
-	c_oid := C.CString(oid)
-	c_start_after := C.CString(startAfter)
-	c_filter_prefix := C.CString(filterPrefix)
-	c_max_return := C.uint64_t(maxReturn)
-
-	defer C.free(unsafe.Pointer(c_oid))
-	defer C.free(unsafe.Pointer(c_start_after))
-	defer C.free(unsafe.Pointer(c_filter_prefix))
-
-	op := C.rados_create_read_op()
-
-	var c_iter C.rados_omap_iter_t
-	var c_prval C.int
-	C.rados_read_op_omap_get_vals2(
-		op,
-		c_start_after,
-		c_filter_prefix,
-		c_max_return,
-		&c_iter,
-		nil,
-		&c_prval,
-	)
-
-	ret := C.rados_read_op_operate(op, ioctx.ioctx, c_oid, 0)
-
-	if int(ret) != 0 {
-		return GetRadosError(int(ret))
-	} else if int(c_prval) != 0 {
-		return RadosError(int(c_prval))
-	}
-
-	for {
-		var c_key *C.char
-		var c_val *C.char
-		var c_len C.size_t
-
-		ret = C.rados_omap_get_next(c_iter, &c_key, &c_val, &c_len)
-
-		if int(ret) != 0 {
-			return GetRadosError(int(ret))
-		}
-
-		if c_key == nil {
-			break
-		}
-
-		listFn(C.GoString(c_key), C.GoBytes(unsafe.Pointer(c_val), C.int(c_len)))
-	}
-
-	C.rados_omap_get_end(c_iter)
-	C.rados_release_read_op(op)
-
-	return nil
-}
-
-// Fetch a set of keys and their values from an omap and returns then as a map
-// `startAfter`: retrieve only the keys after this specified one
-// `filterPrefix`: retrieve only the keys beginning with this prefix
-// `maxReturn`: retrieve no more than `maxReturn` key/value pairs
-func (ioctx *IOContext) GetOmapValues(oid string, startAfter string, filterPrefix string, maxReturn int64) (map[string][]byte, error) {
-	omap := map[string][]byte{}
-
-	err := ioctx.ListOmapValues(
-		oid, startAfter, filterPrefix, maxReturn,
-		func(key string, value []byte) {
-			omap[key] = value
-		},
-	)
-
-	return omap, err
-}
-
-// Fetch all the keys and their values from an omap and returns then as a map
-// `startAfter`: retrieve only the keys after this specified one
-// `filterPrefix`: retrieve only the keys beginning with this prefix
-// `iteratorSize`: internal number of keys to fetch during a read operation
-func (ioctx *IOContext) GetAllOmapValues(oid string, startAfter string, filterPrefix string, iteratorSize int64) (map[string][]byte, error) {
-	omap := map[string][]byte{}
-	omapSize := 0
-
-	for {
-		err := ioctx.ListOmapValues(
-			oid, startAfter, filterPrefix, iteratorSize,
-			func(key string, value []byte) {
-				omap[key] = value
-				startAfter = key
-			},
-		)
-
-		if err != nil {
-			return omap, err
-		}
-
-		// End of omap
-		if len(omap) == omapSize {
-			break
-		}
-
-		omapSize = len(omap)
-	}
-
-	return omap, nil
-}
-
-// Remove the specified `keys` from the omap `oid`
-func (ioctx *IOContext) RmOmapKeys(oid string, keys []string) error {
-	c_oid := C.CString(oid)
-	defer C.free(unsafe.Pointer(c_oid))
-
-	var c *C.char
-	ptrSize := unsafe.Sizeof(c)
-
-	c_keys := C.malloc(C.size_t(len(keys)) * C.size_t(ptrSize))
-	defer C.free(unsafe.Pointer(c_keys))
-
-	i := 0
-	for _, key := range keys {
-		c_key_ptr := (**C.char)(unsafe.Pointer(uintptr(c_keys) + uintptr(i)*ptrSize))
-		*c_key_ptr = C.CString(key)
-		defer C.free(unsafe.Pointer(*c_key_ptr))
-		i++
-	}
-
-	op := C.rados_create_write_op()
-	C.rados_write_op_omap_rm_keys(
-		op,
-		(**C.char)(c_keys),
-		C.size_t(len(keys)))
-
-	ret := C.rados_write_op_operate(op, ioctx.ioctx, c_oid, nil, 0)
-	C.rados_release_write_op(op)
-
-	return GetRadosError(int(ret))
-}
-
-// Clear the omap `oid`
-func (ioctx *IOContext) CleanOmap(oid string) error {
-	c_oid := C.CString(oid)
-	defer C.free(unsafe.Pointer(c_oid))
-
-	op := C.rados_create_write_op()
-	C.rados_write_op_omap_clear(op)
-
-	ret := C.rados_write_op_operate(op, ioctx.ioctx, c_oid, nil, 0)
-	C.rados_release_write_op(op)
-
-	return GetRadosError(int(ret))
-}
-
-type Iter struct {
-	ctx       C.rados_list_ctx_t
-	err       error
-	entry     string
-	namespace string
-}
-
-type IterToken uint32
-
-// Return a Iterator object that can be used to list the object names in the current pool
-func (ioctx *IOContext) Iter() (*Iter, error) {
-	iter := Iter{}
-	if cerr := C.rados_nobjects_list_open(ioctx.ioctx, &iter.ctx); cerr < 0 {
-		return nil, GetRadosError(int(cerr))
-	}
-	return &iter, nil
-}
-
-// Returns a token marking the current position of the iterator. To be used in combination with Iter.Seek()
-func (iter *Iter) Token() IterToken {
-	return IterToken(C.rados_nobjects_list_get_pg_hash_position(iter.ctx))
-}
-
-func (iter *Iter) Seek(token IterToken) {
-	C.rados_nobjects_list_seek(iter.ctx, C.uint32_t(token))
-}
-
-// Next retrieves the next object name in the pool/namespace iterator.
-// Upon a successful invocation (return value of true), the Value method should
-// be used to obtain the name of the retrieved object name. When the iterator is
-// exhausted, Next returns false. The Err method should used to verify whether the
-// end of the iterator was reached, or the iterator received an error.
-//
-// Example:
-//	iter := pool.Iter()
-//	defer iter.Close()
-//	for iter.Next() {
-//		fmt.Printf("%v\n", iter.Value())
-//	}
-//	return iter.Err()
-//
-func (iter *Iter) Next() bool {
-	var c_entry *C.char
-	var c_namespace *C.char
-	if cerr := C.rados_nobjects_list_next(iter.ctx, &c_entry, nil, &c_namespace); cerr < 0 {
-		iter.err = GetRadosError(int(cerr))
-		return false
-	}
-	iter.entry = C.GoString(c_entry)
-	iter.namespace = C.GoString(c_namespace)
-	return true
-}
-
-// Returns the current value of the iterator (object name), after a successful call to Next.
-func (iter *Iter) Value() string {
-	if iter.err != nil {
-		return ""
-	}
-	return iter.entry
-}
-
-// Returns the namespace associated with the current value of the iterator (object name), after a successful call to Next.
-func (iter *Iter) Namespace() string {
-	if iter.err != nil {
-		return ""
-	}
-	return iter.namespace
-}
-
-// Checks whether the iterator has encountered an error.
-func (iter *Iter) Err() error {
-	if iter.err == RadosErrorNotFound {
-		return nil
-	}
-	return iter.err
-}
-
-// Closes the iterator cursor on the server. Be aware that iterators are not closed automatically
-// at the end of iteration.
-func (iter *Iter) Close() {
-	C.rados_nobjects_list_close(iter.ctx)
-}
-
-// Take an exclusive lock on an object.
+// LockExclusive takes an exclusive lock on an object.
 func (ioctx *IOContext) LockExclusive(oid, name, cookie, desc string, duration time.Duration, flags *byte) (int, error) {
 	c_oid := C.CString(oid)
 	c_name := C.CString(name)
@@ -713,11 +470,11 @@ func (ioctx *IOContext) LockExclusive(oid, name, cookie, desc string, duration t
 	case -C.EEXIST:
 		return int(ret), nil
 	default:
-		return int(ret), RadosError(int(ret))
+		return int(ret), getError(ret)
 	}
 }
 
-// Take a shared lock on an object.
+// LockShared takes a shared lock on an object.
 func (ioctx *IOContext) LockShared(oid, name, cookie, tag, desc string, duration time.Duration, flags *byte) (int, error) {
 	c_oid := C.CString(oid)
 	c_name := C.CString(name)
@@ -764,11 +521,11 @@ func (ioctx *IOContext) LockShared(oid, name, cookie, tag, desc string, duration
 	case -C.EEXIST:
 		return int(ret), nil
 	default:
-		return int(ret), RadosError(int(ret))
+		return int(ret), getError(ret)
 	}
 }
 
-// Release a shared or exclusive lock on an object.
+// Unlock releases a shared or exclusive lock on an object.
 func (ioctx *IOContext) Unlock(oid, name, cookie string) (int, error) {
 	c_oid := C.CString(oid)
 	c_name := C.CString(name)
@@ -793,13 +550,15 @@ func (ioctx *IOContext) Unlock(oid, name, cookie string) (int, error) {
 	case -C.ENOENT:
 		return int(ret), nil
 	default:
-		return int(ret), RadosError(int(ret))
+		return int(ret), getError(ret)
 	}
 }
 
-// List clients that have locked the named object lock and information about the lock.
-// The number of bytes required in each buffer is put in the corresponding size out parameter.
-// If any of the provided buffers are too short, -ERANGE is returned after these sizes are filled in.
+// ListLockers lists clients that have locked the named object lock and
+// information about the lock.
+// The number of bytes required in each buffer is put in the corresponding size
+// out parameter.  If any of the provided buffers are too short, -ERANGE is
+// returned after these sizes are filled in.
 func (ioctx *IOContext) ListLockers(oid, name string) (*LockInfo, error) {
 	c_oid := C.CString(oid)
 	c_name := C.CString(name)
@@ -848,13 +607,12 @@ func (ioctx *IOContext) ListLockers(oid, name string) (*LockInfo, error) {
 	}
 
 	if ret < 0 {
-		return nil, RadosError(int(ret))
-	} else {
-		return &LockInfo{int(ret), c_exclusive == 1, C.GoString(c_tag), splitCString(c_clients, c_clients_len), splitCString(c_cookies, c_cookies_len), splitCString(c_addrs, c_addrs_len)}, nil
+		return nil, radosError(ret)
 	}
+	return &LockInfo{int(ret), c_exclusive == 1, C.GoString(c_tag), splitCString(c_clients, c_clients_len), splitCString(c_cookies, c_cookies_len), splitCString(c_addrs, c_addrs_len)}, nil
 }
 
-// Releases a shared or exclusive lock on an object, which was taken by the specified client.
+// BreakLock releases a shared or exclusive lock on an object, which was taken by the specified client.
 func (ioctx *IOContext) BreakLock(oid, name, client, cookie string) (int, error) {
 	c_oid := C.CString(oid)
 	c_name := C.CString(name)
@@ -885,6 +643,19 @@ func (ioctx *IOContext) BreakLock(oid, name, client, cookie string) (int, error)
 	case -C.EINVAL: // -EINVAL
 		return int(ret), nil
 	default:
-		return int(ret), RadosError(int(ret))
+		return int(ret), getError(ret)
 	}
+}
+
+// GetLastVersion will return the version number of the last object read or
+// written to.
+//
+// Implements:
+//  uint64_t rados_get_last_version(rados_ioctx_t io);
+func (ioctx *IOContext) GetLastVersion() (uint64, error) {
+	if err := ioctx.validate(); err != nil {
+		return 0, err
+	}
+	v := C.rados_get_last_version(ioctx.ioctx)
+	return uint64(v), nil
 }

--- a/vendor/github.com/ceph/go-ceph/rados/object_iter.go
+++ b/vendor/github.com/ceph/go-ceph/rados/object_iter.go
@@ -1,0 +1,92 @@
+package rados
+
+// #cgo LDFLAGS: -lrados
+// #include <rados/librados.h>
+//
+import "C"
+
+// Iter supports iterating over objects in the ioctx.
+type Iter struct {
+	ctx       C.rados_list_ctx_t
+	err       error
+	entry     string
+	namespace string
+}
+
+// IterToken supports reporting on and seeking to different positions.
+type IterToken uint32
+
+// Iter returns a Iterator object that can be used to list the object names in the current pool
+func (ioctx *IOContext) Iter() (*Iter, error) {
+	iter := Iter{}
+	if cerr := C.rados_nobjects_list_open(ioctx.ioctx, &iter.ctx); cerr < 0 {
+		return nil, getError(cerr)
+	}
+	return &iter, nil
+}
+
+// Token returns a token marking the current position of the iterator. To be used in combination with Iter.Seek()
+func (iter *Iter) Token() IterToken {
+	return IterToken(C.rados_nobjects_list_get_pg_hash_position(iter.ctx))
+}
+
+// Seek moves the iterator to the position indicated by the token.
+func (iter *Iter) Seek(token IterToken) {
+	C.rados_nobjects_list_seek(iter.ctx, C.uint32_t(token))
+}
+
+// Next retrieves the next object name in the pool/namespace iterator.
+// Upon a successful invocation (return value of true), the Value method should
+// be used to obtain the name of the retrieved object name. When the iterator is
+// exhausted, Next returns false. The Err method should used to verify whether the
+// end of the iterator was reached, or the iterator received an error.
+//
+// Example:
+//	iter := pool.Iter()
+//	defer iter.Close()
+//	for iter.Next() {
+//		fmt.Printf("%v\n", iter.Value())
+//	}
+//	return iter.Err()
+//
+func (iter *Iter) Next() bool {
+	var c_entry *C.char
+	var c_namespace *C.char
+	if cerr := C.rados_nobjects_list_next(iter.ctx, &c_entry, nil, &c_namespace); cerr < 0 {
+		iter.err = getError(cerr)
+		return false
+	}
+	iter.entry = C.GoString(c_entry)
+	iter.namespace = C.GoString(c_namespace)
+	return true
+}
+
+// Value returns the current value of the iterator (object name), after a successful call to Next.
+func (iter *Iter) Value() string {
+	if iter.err != nil {
+		return ""
+	}
+	return iter.entry
+}
+
+// Namespace returns the namespace associated with the current value of the iterator (object name), after a successful call to Next.
+func (iter *Iter) Namespace() string {
+	if iter.err != nil {
+		return ""
+	}
+	return iter.namespace
+}
+
+// Err checks whether the iterator has encountered an error.
+func (iter *Iter) Err() error {
+	if iter.err == ErrNotFound {
+		return nil
+	}
+	return iter.err
+}
+
+// Close the iterator cursor on the server. Be aware that iterators are not closed automatically
+// at the end of iteration.
+func (iter *Iter) Close() {
+	C.rados_nobjects_list_close(iter.ctx)
+}

--- a/vendor/github.com/ceph/go-ceph/rados/omap.go
+++ b/vendor/github.com/ceph/go-ceph/rados/omap.go
@@ -1,0 +1,228 @@
+package rados
+
+// #cgo LDFLAGS: -lrados
+// #include <stdlib.h>
+// #include <rados/librados.h>
+//
+import "C"
+
+import (
+	"unsafe"
+)
+
+// SetOmap appends the map `pairs` to the omap `oid`
+func (ioctx *IOContext) SetOmap(oid string, pairs map[string][]byte) error {
+	c_oid := C.CString(oid)
+	defer C.free(unsafe.Pointer(c_oid))
+
+	var s C.size_t
+	var c *C.char
+	ptrSize := unsafe.Sizeof(c)
+
+	c_keys := C.malloc(C.size_t(len(pairs)) * C.size_t(ptrSize))
+	c_values := C.malloc(C.size_t(len(pairs)) * C.size_t(ptrSize))
+	c_lengths := C.malloc(C.size_t(len(pairs)) * C.size_t(unsafe.Sizeof(s)))
+
+	defer C.free(unsafe.Pointer(c_keys))
+	defer C.free(unsafe.Pointer(c_values))
+	defer C.free(unsafe.Pointer(c_lengths))
+
+	i := 0
+	for key, value := range pairs {
+		// key
+		c_key_ptr := (**C.char)(unsafe.Pointer(uintptr(c_keys) + uintptr(i)*ptrSize))
+		*c_key_ptr = C.CString(key)
+		defer C.free(unsafe.Pointer(*c_key_ptr))
+
+		// value and its length
+		c_value_ptr := (**C.char)(unsafe.Pointer(uintptr(c_values) + uintptr(i)*ptrSize))
+
+		var c_length C.size_t
+		if len(value) > 0 {
+			*c_value_ptr = (*C.char)(unsafe.Pointer(&value[0]))
+			c_length = C.size_t(len(value))
+		} else {
+			*c_value_ptr = nil
+			c_length = C.size_t(0)
+		}
+
+		c_length_ptr := (*C.size_t)(unsafe.Pointer(uintptr(c_lengths) + uintptr(i)*ptrSize))
+		*c_length_ptr = c_length
+
+		i++
+	}
+
+	op := C.rados_create_write_op()
+	C.rados_write_op_omap_set(
+		op,
+		(**C.char)(c_keys),
+		(**C.char)(c_values),
+		(*C.size_t)(c_lengths),
+		C.size_t(len(pairs)))
+
+	ret := C.rados_write_op_operate(op, ioctx.ioctx, c_oid, nil, 0)
+	C.rados_release_write_op(op)
+
+	return getError(ret)
+}
+
+// OmapListFunc is the type of the function called for each omap key
+// visited by ListOmapValues
+type OmapListFunc func(key string, value []byte)
+
+// ListOmapValues iterates over the keys and values in an omap by way of
+// a callback function.
+//
+// `startAfter`: iterate only on the keys after this specified one
+// `filterPrefix`: iterate only on the keys beginning with this prefix
+// `maxReturn`: iterate no more than `maxReturn` key/value pairs
+// `listFn`: the function called at each iteration
+func (ioctx *IOContext) ListOmapValues(oid string, startAfter string, filterPrefix string, maxReturn int64, listFn OmapListFunc) error {
+	c_oid := C.CString(oid)
+	c_start_after := C.CString(startAfter)
+	c_filter_prefix := C.CString(filterPrefix)
+	c_max_return := C.uint64_t(maxReturn)
+
+	defer C.free(unsafe.Pointer(c_oid))
+	defer C.free(unsafe.Pointer(c_start_after))
+	defer C.free(unsafe.Pointer(c_filter_prefix))
+
+	op := C.rados_create_read_op()
+
+	var c_iter C.rados_omap_iter_t
+	var c_prval C.int
+	C.rados_read_op_omap_get_vals2(
+		op,
+		c_start_after,
+		c_filter_prefix,
+		c_max_return,
+		&c_iter,
+		nil,
+		&c_prval,
+	)
+
+	ret := C.rados_read_op_operate(op, ioctx.ioctx, c_oid, 0)
+
+	if int(ret) != 0 {
+		return getError(ret)
+	} else if int(c_prval) != 0 {
+		return getError(c_prval)
+	}
+
+	for {
+		var c_key *C.char
+		var c_val *C.char
+		var c_len C.size_t
+
+		ret = C.rados_omap_get_next(c_iter, &c_key, &c_val, &c_len)
+
+		if int(ret) != 0 {
+			return getError(ret)
+		}
+
+		if c_key == nil {
+			break
+		}
+
+		listFn(C.GoString(c_key), C.GoBytes(unsafe.Pointer(c_val), C.int(c_len)))
+	}
+
+	C.rados_omap_get_end(c_iter)
+	C.rados_release_read_op(op)
+
+	return nil
+}
+
+// GetOmapValues fetches a set of keys and their values from an omap and returns then as a map
+// `startAfter`: retrieve only the keys after this specified one
+// `filterPrefix`: retrieve only the keys beginning with this prefix
+// `maxReturn`: retrieve no more than `maxReturn` key/value pairs
+func (ioctx *IOContext) GetOmapValues(oid string, startAfter string, filterPrefix string, maxReturn int64) (map[string][]byte, error) {
+	omap := map[string][]byte{}
+
+	err := ioctx.ListOmapValues(
+		oid, startAfter, filterPrefix, maxReturn,
+		func(key string, value []byte) {
+			omap[key] = value
+		},
+	)
+
+	return omap, err
+}
+
+// GetAllOmapValues fetches all the keys and their values from an omap and returns then as a map
+// `startAfter`: retrieve only the keys after this specified one
+// `filterPrefix`: retrieve only the keys beginning with this prefix
+// `iteratorSize`: internal number of keys to fetch during a read operation
+func (ioctx *IOContext) GetAllOmapValues(oid string, startAfter string, filterPrefix string, iteratorSize int64) (map[string][]byte, error) {
+	omap := map[string][]byte{}
+	omapSize := 0
+
+	for {
+		err := ioctx.ListOmapValues(
+			oid, startAfter, filterPrefix, iteratorSize,
+			func(key string, value []byte) {
+				omap[key] = value
+				startAfter = key
+			},
+		)
+
+		if err != nil {
+			return omap, err
+		}
+
+		// End of omap
+		if len(omap) == omapSize {
+			break
+		}
+
+		omapSize = len(omap)
+	}
+
+	return omap, nil
+}
+
+// RmOmapKeys removes the specified `keys` from the omap `oid`
+func (ioctx *IOContext) RmOmapKeys(oid string, keys []string) error {
+	c_oid := C.CString(oid)
+	defer C.free(unsafe.Pointer(c_oid))
+
+	var c *C.char
+	ptrSize := unsafe.Sizeof(c)
+
+	c_keys := C.malloc(C.size_t(len(keys)) * C.size_t(ptrSize))
+	defer C.free(unsafe.Pointer(c_keys))
+
+	i := 0
+	for _, key := range keys {
+		c_key_ptr := (**C.char)(unsafe.Pointer(uintptr(c_keys) + uintptr(i)*ptrSize))
+		*c_key_ptr = C.CString(key)
+		defer C.free(unsafe.Pointer(*c_key_ptr))
+		i++
+	}
+
+	op := C.rados_create_write_op()
+	C.rados_write_op_omap_rm_keys(
+		op,
+		(**C.char)(c_keys),
+		C.size_t(len(keys)))
+
+	ret := C.rados_write_op_operate(op, ioctx.ioctx, c_oid, nil, 0)
+	C.rados_release_write_op(op)
+
+	return getError(ret)
+}
+
+// CleanOmap clears the omap `oid`
+func (ioctx *IOContext) CleanOmap(oid string) error {
+	c_oid := C.CString(oid)
+	defer C.free(unsafe.Pointer(c_oid))
+
+	op := C.rados_create_write_op()
+	C.rados_write_op_omap_clear(op)
+
+	ret := C.rados_write_op_operate(op, ioctx.ioctx, c_oid, nil, 0)
+	C.rados_release_write_op(op)
+
+	return getError(ret)
+}

--- a/vendor/github.com/ceph/go-ceph/rados/rados_test.go
+++ b/vendor/github.com/ceph/go-ceph/rados/rados_test.go
@@ -1,0 +1,1273 @@
+package rados
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"sort"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type RadosTestSuite struct {
+	suite.Suite
+	conn  *Conn
+	ioctx *IOContext
+	pool  string
+	count int
+}
+
+func (suite *RadosTestSuite) SetupSuite() {
+	conn, err := NewConn()
+	require.NoError(suite.T(), err)
+	defer conn.Shutdown()
+
+	err = conn.ReadDefaultConfigFile()
+	require.NoError(suite.T(), err)
+
+	timeout := time.After(time.Second * 5)
+	ch := make(chan error)
+	go func(conn *Conn) {
+		ch <- conn.Connect()
+	}(conn)
+	select {
+	case err = <-ch:
+	case <-timeout:
+		err = fmt.Errorf("timed out waiting for connect")
+	}
+
+	if assert.NoError(suite.T(), err) {
+		pool := uuid.Must(uuid.NewV4()).String()
+		if err = conn.MakePool(pool); assert.NoError(suite.T(), err) {
+			suite.pool = pool
+			return
+		}
+	}
+
+	suite.T().FailNow()
+}
+
+func (suite *RadosTestSuite) SetupTest() {
+	suite.conn = nil
+	suite.ioctx = nil
+	suite.count = 0
+
+	conn, err := NewConn()
+	require.NoError(suite.T(), err)
+	suite.conn = conn
+	err = suite.conn.ReadDefaultConfigFile()
+	require.NoError(suite.T(), err)
+}
+
+func (suite *RadosTestSuite) SetupConnection() {
+	if err := suite.conn.Connect(); assert.NoError(suite.T(), err) {
+		ioctx, err := suite.conn.OpenIOContext(suite.pool)
+		if assert.NoError(suite.T(), err) {
+			suite.ioctx = ioctx
+			return
+		}
+	}
+	suite.conn.Shutdown()
+	suite.T().FailNow()
+}
+
+func (suite *RadosTestSuite) GenObjectName() string {
+	name := fmt.Sprintf("%s_%d", suite.T().Name(), suite.count)
+	suite.count++
+	return name
+}
+
+func (suite *RadosTestSuite) RandomBytes(size int) []byte {
+	bytes := make([]byte, size)
+	n, err := rand.Read(bytes)
+	require.Equal(suite.T(), n, size)
+	require.NoError(suite.T(), err)
+	return bytes
+}
+
+func (suite *RadosTestSuite) TearDownTest() {
+	if suite.ioctx != nil {
+		suite.ioctx.Destroy()
+	}
+	suite.conn.Shutdown()
+}
+
+func (suite *RadosTestSuite) TearDownSuite() {
+	conn, err := NewConn()
+	require.NoError(suite.T(), err)
+	defer conn.Shutdown()
+
+	err = conn.ReadDefaultConfigFile()
+	require.NoError(suite.T(), err)
+
+	if err = conn.Connect(); assert.NoError(suite.T(), err) {
+		err = conn.DeletePool(suite.pool)
+		assert.NoError(suite.T(), err)
+	}
+}
+
+func TestVersion(t *testing.T) {
+	var major, minor, patch = Version()
+	assert.False(t, major < 0 || major > 1000, "invalid major")
+	assert.False(t, minor < 0 || minor > 1000, "invalid minor")
+	assert.False(t, patch < 0 || patch > 1000, "invalid patch")
+}
+
+func (suite *RadosTestSuite) TestGetFSID() {
+	fsid, err := suite.conn.GetFSID()
+	assert.NoError(suite.T(), err)
+	assert.NotEqual(suite.T(), fsid, "")
+}
+
+func (suite *RadosTestSuite) TestGetSetConfigOption() {
+	// rejects invalid options
+	err := suite.conn.SetConfigOption("___dne___", "value")
+	assert.Error(suite.T(), err, "Invalid option")
+
+	// check error for  get invalid option
+	_, err = suite.conn.GetConfigOption("__dne__")
+	assert.Error(suite.T(), err)
+
+	// verify SetConfigOption changes a values
+	prev_val, err := suite.conn.GetConfigOption("log_file")
+	assert.NoError(suite.T(), err, "Invalid option")
+
+	err = suite.conn.SetConfigOption("log_file", "/dev/null")
+	assert.NoError(suite.T(), err, "Invalid option")
+
+	curr_val, err := suite.conn.GetConfigOption("log_file")
+	assert.NoError(suite.T(), err, "Invalid option")
+
+	assert.NotEqual(suite.T(), prev_val, "/dev/null")
+	assert.Equal(suite.T(), curr_val, "/dev/null")
+}
+
+func (suite *RadosTestSuite) TestParseDefaultConfigEnv() {
+	prev_val, err := suite.conn.GetConfigOption("log_file")
+	assert.NoError(suite.T(), err, "Invalid option")
+
+	err = os.Setenv("CEPH_ARGS", "--log-file /dev/null")
+	assert.NoError(suite.T(), err)
+
+	err = suite.conn.ParseDefaultConfigEnv()
+	assert.NoError(suite.T(), err)
+
+	curr_val, err := suite.conn.GetConfigOption("log_file")
+	assert.NoError(suite.T(), err, "Invalid option")
+
+	assert.NotEqual(suite.T(), prev_val, "/dev/null")
+	assert.Equal(suite.T(), curr_val, "/dev/null")
+}
+
+func (suite *RadosTestSuite) TestParseConfigArgv() {
+	prev_val, err := suite.conn.GetConfigOption("log_file")
+	assert.NoError(suite.T(), err, "Invalid option")
+
+	argv := []string{"rados.test", "--log_file", "/dev/null"}
+	err = suite.conn.ParseConfigArgv(argv)
+	assert.NoError(suite.T(), err)
+
+	curr_val, err := suite.conn.GetConfigOption("log_file")
+	assert.NoError(suite.T(), err, "Invalid option")
+
+	assert.NotEqual(suite.T(), prev_val, "/dev/null")
+	assert.Equal(suite.T(), curr_val, "/dev/null")
+
+	// ensure that an empty slice triggers an error (not a crash)
+	err = suite.conn.ParseConfigArgv([]string{})
+	assert.Error(suite.T(), err)
+
+	// ensure we get an error for an invalid conn value
+	badConn := &Conn{}
+	err = badConn.ParseConfigArgv(
+		[]string{"cephfs.test", "--log_file", "/dev/null"})
+	assert.Error(suite.T(), err)
+}
+
+func (suite *RadosTestSuite) TestParseCmdLineArgs() {
+	prev_val, err := suite.conn.GetConfigOption("log_file")
+	assert.NoError(suite.T(), err, "Invalid option")
+
+	args := []string{"--log_file", "/dev/null"}
+	err = suite.conn.ParseCmdLineArgs(args)
+	assert.NoError(suite.T(), err)
+
+	curr_val, err := suite.conn.GetConfigOption("log_file")
+	assert.NoError(suite.T(), err, "Invalid option")
+
+	assert.NotEqual(suite.T(), prev_val, "/dev/null")
+	assert.Equal(suite.T(), curr_val, "/dev/null")
+}
+
+func (suite *RadosTestSuite) TestReadConfigFile() {
+	// check current log_file value
+	prev_str, err := suite.conn.GetConfigOption("log_max_new")
+	assert.NoError(suite.T(), err)
+
+	prev_val, err := strconv.Atoi(prev_str)
+	assert.NoError(suite.T(), err)
+
+	// create conf file that changes log_file conf option
+	file, err := ioutil.TempFile("/tmp", "go-rados")
+	require.NoError(suite.T(), err)
+	defer func() {
+		assert.NoError(suite.T(), file.Close())
+		assert.NoError(suite.T(), os.Remove(file.Name()))
+	}()
+
+	next_val := prev_val + 1
+	conf := fmt.Sprintf("[global]\nlog_max_new = %d\n", next_val)
+	_, err = io.WriteString(file, conf)
+	assert.NoError(suite.T(), err)
+
+	// parse the config file
+	err = suite.conn.ReadConfigFile(file.Name())
+	assert.NoError(suite.T(), err)
+
+	// check current log_file value
+	curr_str, err := suite.conn.GetConfigOption("log_max_new")
+	assert.NoError(suite.T(), err)
+
+	curr_val, err := strconv.Atoi(curr_str)
+	assert.NoError(suite.T(), err)
+
+	assert.NotEqual(suite.T(), prev_str, curr_str)
+	assert.Equal(suite.T(), curr_val, prev_val+1)
+}
+
+func (suite *RadosTestSuite) TestGetClusterStats() {
+	suite.SetupConnection()
+
+	// grab current stats
+	prev_stat, err := suite.conn.GetClusterStats()
+	fmt.Printf("prev_stat: %+v\n", prev_stat)
+	assert.NoError(suite.T(), err)
+
+	// make some changes to the cluster
+	buf := make([]byte, 1<<20)
+	for i := 0; i < 10; i++ {
+		objname := suite.GenObjectName()
+		err = suite.ioctx.Write(objname, buf, 0)
+		assert.NoError(suite.T(), err)
+	}
+
+	// wait a while for the stats to change
+	for i := 0; i < 30; i++ {
+		stat, err := suite.conn.GetClusterStats()
+		assert.NoError(suite.T(), err)
+
+		// wait for something to change
+		if stat == prev_stat {
+			fmt.Printf("curr_stat: %+v (trying again...)\n", stat)
+			time.Sleep(time.Second)
+		} else {
+			// success
+			fmt.Printf("curr_stat: %+v (change detected)\n", stat)
+			return
+		}
+	}
+
+	suite.T().Error("Cluster stats aren't changing")
+}
+
+func (suite *RadosTestSuite) TestGetInstanceID() {
+	suite.SetupConnection()
+
+	id := suite.conn.GetInstanceID()
+	assert.NotEqual(suite.T(), id, 0)
+}
+
+func (suite *RadosTestSuite) TestMakeDeletePool() {
+	suite.SetupConnection()
+
+	// check that new pool name is unique
+	new_name := uuid.Must(uuid.NewV4()).String()
+	_, err := suite.conn.GetPoolByName(new_name)
+	if err == nil {
+		suite.T().Error("Random pool name exists!")
+		return
+	}
+
+	// create pool
+	err = suite.conn.MakePool(new_name)
+	assert.NoError(suite.T(), err)
+
+	// verify that the new pool name exists
+	pool, err := suite.conn.GetPoolByName(new_name)
+	assert.NoError(suite.T(), err)
+
+	if pool == 0 {
+		suite.T().Error("Cannot find newly created pool")
+	}
+
+	// delete the pool
+	err = suite.conn.DeletePool(new_name)
+	assert.NoError(suite.T(), err)
+
+	// verify that it is gone
+	pool, _ = suite.conn.GetPoolByName(new_name)
+	if pool != 0 {
+		suite.T().Error("Deleted pool still exists")
+	}
+}
+
+func (suite *RadosTestSuite) TestGetPoolByName() {
+	suite.SetupConnection()
+
+	// get current list of pool
+	pools, err := suite.conn.ListPools()
+	assert.NoError(suite.T(), err)
+
+	// check that new pool name is unique
+	new_name := uuid.Must(uuid.NewV4()).String()
+	require.NotContains(
+		suite.T(), pools, new_name, "Random pool name exists!")
+
+	pool, _ := suite.conn.GetPoolByName(new_name)
+	assert.Equal(suite.T(), int64(0), pool, "Pool does not exist, but was found!")
+
+	// create pool
+	err = suite.conn.MakePool(new_name)
+	assert.NoError(suite.T(), err)
+
+	// verify that the new pool name exists
+	pools, err = suite.conn.ListPools()
+	assert.NoError(suite.T(), err)
+	assert.Contains(
+		suite.T(), pools, new_name, "Cannot find newly created pool")
+
+	pool, err = suite.conn.GetPoolByName(new_name)
+	assert.NoError(suite.T(), err)
+	assert.NotEqual(suite.T(), int64(0), pool, "Pool not found!")
+
+	// delete the pool
+	err = suite.conn.DeletePool(new_name)
+	assert.NoError(suite.T(), err)
+
+	// verify that it is gone
+	pools, err = suite.conn.ListPools()
+	assert.NoError(suite.T(), err)
+	assert.NotContains(
+		suite.T(), pools, new_name, "Deleted pool still exists")
+
+	pool, err = suite.conn.GetPoolByName(new_name)
+	assert.Error(suite.T(), err)
+	assert.Equal(
+		suite.T(), int64(0), pool, "Pool should have been deleted, but was found!")
+}
+
+func (suite *RadosTestSuite) TestGetPoolByID() {
+	suite.SetupConnection()
+
+	// check that new pool name is unique
+	new_name := uuid.Must(uuid.NewV4()).String()
+	pool, err := suite.conn.GetPoolByName(new_name)
+	if pool != 0 || err == nil {
+		suite.T().Error("Random pool name exists!")
+		return
+	}
+
+	// create pool
+	err = suite.conn.MakePool(new_name)
+	assert.NoError(suite.T(), err)
+
+	// verify that the new pool name exists
+	id, err := suite.conn.GetPoolByName(new_name)
+	assert.NoError(suite.T(), err)
+
+	if id == 0 {
+		suite.T().Error("Cannot find newly created pool")
+	}
+
+	// get the name of the pool
+	name, err := suite.conn.GetPoolByID(id)
+	assert.NoError(suite.T(), err)
+
+	if name == "" {
+		suite.T().Error("Cannot find name of newly created pool")
+	}
+
+	// delete the pool
+	err = suite.conn.DeletePool(new_name)
+	assert.NoError(suite.T(), err)
+
+	// verify that it is gone
+	name, err = suite.conn.GetPoolByID(id)
+	if name != "" || err == nil {
+		suite.T().Error("Deleted pool still exists")
+	}
+}
+
+func (suite *RadosTestSuite) TestGetLargePoolList() {
+	suite.SetupConnection()
+
+	// get current list of pool
+	pools, err := suite.conn.ListPools()
+	assert.NoError(suite.T(), err)
+
+	fill := func(r rune) string {
+		b := make([]rune, 512)
+		for i := range b {
+			b[i] = r
+		}
+		return string(b)
+	}
+	// try to ensure we exceed the default 4096 byte initial buffer
+	// size and make use of the increased buffer size code path
+	names := []string{
+		fill('a'),
+		fill('b'),
+		fill('c'),
+		fill('d'),
+		fill('e'),
+		fill('f'),
+		fill('g'),
+		fill('h'),
+		fill('i'),
+		fill('j'),
+	}
+
+	defer func(origPools []string) {
+		for _, name := range names {
+			err := suite.conn.DeletePool(name)
+			assert.NoError(suite.T(), err)
+		}
+		cleanPools, err := suite.conn.ListPools()
+		assert.NoError(suite.T(), err)
+		assert.Equal(suite.T(), origPools, cleanPools)
+	}(pools)
+
+	for _, name := range names {
+		err = suite.conn.MakePool(name)
+		require.NoError(suite.T(), err)
+	}
+	pools, err = suite.conn.ListPools()
+	for _, name := range names {
+		assert.Contains(suite.T(), pools, name)
+	}
+}
+
+func (suite *RadosTestSuite) TestPingMonitor() {
+	suite.SetupConnection()
+
+	// mon id that should work with vstart.sh
+	reply, err := suite.conn.PingMonitor("a")
+	assert.NoError(suite.T(), err)
+	assert.NotEqual(suite.T(), reply, "")
+
+	// invalid mon id
+	reply, err = suite.conn.PingMonitor("charlieB")
+	assert.Error(suite.T(), err)
+	assert.Equal(suite.T(), reply, "")
+}
+
+func (suite *RadosTestSuite) TestWaitForLatestOSDMap() {
+	suite.SetupConnection()
+
+	err := suite.conn.WaitForLatestOSDMap()
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *RadosTestSuite) TestCreate() {
+	suite.SetupConnection()
+
+	err := suite.ioctx.Create("unique", CreateExclusive)
+	assert.NoError(suite.T(), err)
+
+	err = suite.ioctx.Create("unique", CreateExclusive)
+	assert.Error(suite.T(), err)
+	assert.Equal(suite.T(), err, ErrObjectExists)
+
+	err = suite.ioctx.Create("unique", CreateIdempotent)
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *RadosTestSuite) TestReadWrite() {
+	suite.SetupConnection()
+
+	bytes_in := []byte("input data")
+	err := suite.ioctx.Write("obj", bytes_in, 0)
+	assert.NoError(suite.T(), err)
+
+	bytes_out := make([]byte, len(bytes_in))
+	n_out, err := suite.ioctx.Read("obj", bytes_out, 0)
+
+	assert.Equal(suite.T(), n_out, len(bytes_in))
+	assert.Equal(suite.T(), bytes_in, bytes_out)
+
+	bytes_in = []byte("input another data")
+	err = suite.ioctx.WriteFull("obj", bytes_in)
+	assert.NoError(suite.T(), err)
+
+	bytes_out = make([]byte, len(bytes_in))
+	n_out, err = suite.ioctx.Read("obj", bytes_out, 0)
+
+	assert.Equal(suite.T(), n_out, len(bytes_in))
+	assert.Equal(suite.T(), bytes_in, bytes_out)
+}
+
+func (suite *RadosTestSuite) TestAppend() {
+	suite.SetupConnection()
+
+	mirror := []byte{}
+	oid := suite.GenObjectName()
+	for i := 0; i < 3; i++ {
+		// append random bytes
+		bytes := suite.RandomBytes(33)
+		err := suite.ioctx.Append(oid, bytes)
+		assert.NoError(suite.T(), err)
+
+		// what the object should contain
+		mirror = append(mirror, bytes...)
+
+		// check object contains what we expect
+		buf := make([]byte, len(mirror))
+		n, err := suite.ioctx.Read(oid, buf, 0)
+		assert.NoError(suite.T(), err)
+		assert.Equal(suite.T(), n, len(buf))
+		assert.Equal(suite.T(), buf, mirror)
+	}
+}
+
+func (suite *RadosTestSuite) TestReadNotFound() {
+	suite.SetupConnection()
+
+	var bytes []byte
+	oid := suite.GenObjectName()
+	_, err := suite.ioctx.Read(oid, bytes, 0)
+	assert.Equal(suite.T(), err, ErrNotFound)
+}
+
+func (suite *RadosTestSuite) TestDeleteNotFound() {
+	suite.SetupConnection()
+
+	oid := suite.GenObjectName()
+	err := suite.ioctx.Delete(oid)
+	assert.Equal(suite.T(), err, ErrNotFound)
+}
+
+func (suite *RadosTestSuite) TestStatNotFound() {
+	suite.SetupConnection()
+
+	oid := suite.GenObjectName()
+	_, err := suite.ioctx.Stat(oid)
+	assert.Equal(suite.T(), err, ErrNotFound)
+}
+
+func (suite *RadosTestSuite) TestObjectStat() {
+	suite.SetupConnection()
+
+	oid := suite.GenObjectName()
+	bytes := suite.RandomBytes(234)
+	err := suite.ioctx.Write(oid, bytes, 0)
+	assert.NoError(suite.T(), err)
+
+	stat, err := suite.ioctx.Stat(oid)
+	assert.Equal(suite.T(), uint64(len(bytes)), stat.Size)
+	assert.NotNil(suite.T(), stat.ModTime)
+}
+
+func (suite *RadosTestSuite) TestGetPoolStats() {
+	suite.SetupConnection()
+
+	// grab current stats
+	prev_stat, err := suite.ioctx.GetPoolStats()
+	fmt.Printf("prev_stat: %+v\n", prev_stat)
+	assert.NoError(suite.T(), err)
+
+	// make some changes to the cluster
+	buf := make([]byte, 1<<20)
+	for i := 0; i < 10; i++ {
+		oid := suite.GenObjectName()
+		err = suite.ioctx.Write(oid, buf, 0)
+		assert.NoError(suite.T(), err)
+	}
+
+	// wait a while for the stats to change
+	for i := 0; i < 30; i++ {
+		stat, err := suite.ioctx.GetPoolStats()
+		assert.NoError(suite.T(), err)
+
+		// wait for something to change
+		if stat == prev_stat {
+			fmt.Printf("curr_stat: %+v (trying again...)\n", stat)
+			time.Sleep(time.Second)
+		} else {
+			// success
+			fmt.Printf("curr_stat: %+v (change detected)\n", stat)
+			return
+		}
+	}
+
+	suite.T().Error("Pool stats aren't changing")
+}
+
+func (suite *RadosTestSuite) TestGetPoolID() {
+	suite.SetupConnection()
+
+	poolIDByName, err := suite.conn.GetPoolByName(suite.pool)
+	assert.NoError(suite.T(), err)
+	assert.NotEqual(suite.T(), int64(0), poolIDByName)
+
+	poolID := suite.ioctx.GetPoolID()
+	assert.Equal(suite.T(), poolIDByName, poolID)
+}
+
+func (suite *RadosTestSuite) TestGetPoolName() {
+	suite.SetupConnection()
+
+	name, err := suite.ioctx.GetPoolName()
+	assert.NoError(suite.T(), err)
+
+	assert.Equal(suite.T(), name, suite.pool)
+}
+
+func (suite *RadosTestSuite) TestObjectListObjects() {
+	suite.SetupConnection()
+
+	// objects currently in pool
+	prevObjectList := []string{}
+	err := suite.ioctx.ListObjects(func(oid string) {
+		prevObjectList = append(prevObjectList, oid)
+	})
+	assert.NoError(suite.T(), err)
+
+	// create some objects
+	createdList := []string{}
+	for i := 0; i < 10; i++ {
+		oid := suite.GenObjectName()
+		bytes := []byte("input data")
+		err := suite.ioctx.Write(oid, bytes, 0)
+		assert.NoError(suite.T(), err)
+		createdList = append(createdList, oid)
+	}
+
+	// join the lists of objects
+	expectedObjectList := prevObjectList
+	expectedObjectList = append(expectedObjectList, createdList...)
+
+	// now list the current set of objects in the pool
+	currObjectList := []string{}
+	err = suite.ioctx.ListObjects(func(oid string) {
+		currObjectList = append(currObjectList, oid)
+	})
+	assert.NoError(suite.T(), err)
+
+	// lists should be equal
+	sort.Strings(currObjectList)
+	sort.Strings(expectedObjectList)
+	assert.Equal(suite.T(), currObjectList, expectedObjectList)
+}
+
+func (suite *RadosTestSuite) TestObjectIterator() {
+	suite.SetupConnection()
+
+	// current objs in default namespace
+	prevObjectList := []string{}
+	iter, err := suite.ioctx.Iter()
+	assert.NoError(suite.T(), err)
+	for iter.Next() {
+		prevObjectList = append(prevObjectList, iter.Value())
+	}
+	iter.Close()
+	assert.NoError(suite.T(), iter.Err())
+
+	// create an object in a different namespace to verify that
+	// iteration within a namespace does not return it
+	suite.ioctx.SetNamespace("ns1")
+	bytes_in := []byte("input data")
+	err = suite.ioctx.Write(suite.GenObjectName(), bytes_in, 0)
+	assert.NoError(suite.T(), err)
+
+	// create some objects in default namespace
+	suite.ioctx.SetNamespace("")
+	createdList := []string{}
+	for i := 0; i < 10; i++ {
+		oid := suite.GenObjectName()
+		bytes_in := []byte("input data")
+		err = suite.ioctx.Write(oid, bytes_in, 0)
+		assert.NoError(suite.T(), err)
+		createdList = append(createdList, oid)
+	}
+
+	// prev list plus new oids
+	expectedObjectList := prevObjectList
+	expectedObjectList = append(expectedObjectList, createdList...)
+
+	currObjectList := []string{}
+	iter, err = suite.ioctx.Iter()
+	assert.NoError(suite.T(), err)
+	for iter.Next() {
+		currObjectList = append(currObjectList, iter.Value())
+	}
+	iter.Close()
+	assert.NoError(suite.T(), iter.Err())
+
+	// curr list doesn't include the obj in ns1
+	sort.Strings(expectedObjectList)
+	sort.Strings(currObjectList)
+	assert.Equal(suite.T(), currObjectList, expectedObjectList)
+}
+
+func (suite *RadosTestSuite) TestObjectIteratorAcrossNamespaces() {
+	suite.SetupConnection()
+
+	const perNamespace = 100
+
+	// tests use a shared pool so namespaces need to be unique across tests.
+	// below ns1=nsX and ns2=nsY. ns1 is used elsewhere.
+	objectListNS1 := []string{}
+	objectListNS2 := []string{}
+
+	// populate list of current objects
+	suite.ioctx.SetNamespace(AllNamespaces)
+	existingList := []string{}
+	iter, err := suite.ioctx.Iter()
+	assert.NoError(suite.T(), err)
+	for iter.Next() {
+		existingList = append(existingList, iter.Value())
+	}
+	iter.Close()
+	assert.NoError(suite.T(), iter.Err())
+
+	// create some new objects in namespace: nsX
+	createdList := []string{}
+	suite.ioctx.SetNamespace("nsX")
+	for i := 0; i < 10; i++ {
+		oid := suite.GenObjectName()
+		bytes_in := []byte("input data")
+		err = suite.ioctx.Write(oid, bytes_in, 0)
+		assert.NoError(suite.T(), err)
+		createdList = append(createdList, oid)
+	}
+	assert.True(suite.T(), len(createdList) == 10)
+
+	// create some new objects in namespace: nsY
+	suite.ioctx.SetNamespace("nsY")
+	for i := 0; i < 10; i++ {
+		oid := suite.GenObjectName()
+		bytes_in := []byte("input data")
+		err = suite.ioctx.Write(oid, bytes_in, 0)
+		assert.NoError(suite.T(), err)
+		createdList = append(createdList, oid)
+	}
+	assert.True(suite.T(), len(createdList) == 20)
+
+	suite.ioctx.SetNamespace(AllNamespaces)
+	iter, err = suite.ioctx.Iter()
+	assert.NoError(suite.T(), err)
+	rogueList := []string{}
+	for iter.Next() {
+		if iter.Namespace() == "nsX" {
+			objectListNS1 = append(objectListNS1, iter.Value())
+		} else if iter.Namespace() == "nsY" {
+			objectListNS2 = append(objectListNS2, iter.Value())
+		} else {
+			rogueList = append(rogueList, iter.Value())
+		}
+	}
+	iter.Close()
+	assert.NoError(suite.T(), iter.Err())
+
+	assert.Equal(suite.T(), len(existingList), len(rogueList))
+	assert.Equal(suite.T(), len(objectListNS1), 10)
+	assert.Equal(suite.T(), len(objectListNS2), 10)
+
+	objectList := []string{}
+	objectList = append(objectList, objectListNS1...)
+	objectList = append(objectList, objectListNS2...)
+	sort.Strings(objectList)
+	sort.Strings(createdList)
+
+	assert.Equal(suite.T(), objectList, createdList)
+
+	sort.Strings(rogueList)
+	sort.Strings(existingList)
+	assert.Equal(suite.T(), rogueList, existingList)
+}
+
+func (suite *RadosTestSuite) TestNewConnWithUser() {
+	_, err := NewConnWithUser("admin")
+	assert.Equal(suite.T(), err, nil)
+}
+
+func (suite *RadosTestSuite) TestNewConnWithClusterAndUser() {
+	_, err := NewConnWithClusterAndUser("ceph", "client.admin")
+	assert.Equal(suite.T(), err, nil)
+}
+
+func (suite *RadosTestSuite) TestReadWriteXattr() {
+	suite.SetupConnection()
+
+	oid := suite.GenObjectName()
+	val := []byte("value")
+	err := suite.ioctx.SetXattr(oid, "key", val)
+	assert.NoError(suite.T(), err)
+
+	out := make([]byte, len(val))
+	n, err := suite.ioctx.GetXattr(oid, "key", out)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), n, len(out))
+
+	assert.Equal(suite.T(), out, val)
+}
+
+func (suite *RadosTestSuite) TestListXattrs() {
+	suite.SetupConnection()
+
+	oid := suite.GenObjectName()
+	xattrs := make(map[string][]byte)
+	val := []byte("value")
+	for i := 0; i < 10; i++ {
+		name := fmt.Sprintf("key_%d", i)
+		err := suite.ioctx.SetXattr(oid, name, val)
+		assert.NoError(suite.T(), err)
+		xattrs[name] = val
+	}
+
+	out, err := suite.ioctx.ListXattrs(oid)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), xattrs, out)
+}
+
+func (suite *RadosTestSuite) TestRmXattr() {
+	suite.SetupConnection()
+
+	oid := suite.GenObjectName()
+
+	// 2 xattrs
+	xattrs := make(map[string][]byte)
+	xattrs["key1"] = []byte("val")
+	xattrs["key2"] = []byte("val")
+	assert.Equal(suite.T(), len(xattrs), 2)
+
+	// add them to the object
+	for key, value := range xattrs {
+		err := suite.ioctx.SetXattr(oid, key, value)
+		assert.NoError(suite.T(), err)
+	}
+	out, err := suite.ioctx.ListXattrs(oid)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), len(out), 2)
+	assert.Equal(suite.T(), out, xattrs)
+
+	// remove key1
+	err = suite.ioctx.RmXattr(oid, "key1")
+	assert.NoError(suite.T(), err)
+	delete(xattrs, "key1")
+
+	// verify key1 is gone
+	out, err = suite.ioctx.ListXattrs(oid)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), len(out), 1)
+	assert.Equal(suite.T(), out, xattrs)
+
+	// remove key2
+	err = suite.ioctx.RmXattr(oid, "key2")
+	assert.NoError(suite.T(), err)
+	delete(xattrs, "key2")
+
+	// verify key2 is gone
+	out, err = suite.ioctx.ListXattrs(oid)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), len(out), 0)
+	assert.Equal(suite.T(), out, xattrs)
+}
+
+func (suite *RadosTestSuite) TestReadWriteOmap() {
+	suite.SetupConnection()
+
+	// set some key/value pairs on an object
+	orig := map[string][]byte{
+		"key1":          []byte("value1"),
+		"key2":          []byte("value2"),
+		"prefixed-key3": []byte("value3"),
+		"empty":         []byte(""),
+	}
+
+	oid := suite.GenObjectName()
+	err := suite.ioctx.SetOmap(oid, orig)
+	assert.NoError(suite.T(), err)
+
+	// verify that they can all be read back
+	remaining := map[string][]byte{}
+	for k, v := range orig {
+		remaining[k] = v
+	}
+
+	err = suite.ioctx.ListOmapValues(oid, "", "", 4, func(key string, value []byte) {
+		assert.Equal(suite.T(), remaining[key], value)
+		delete(remaining, key)
+	})
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), len(remaining), 0)
+
+	// Get (with a fixed number of keys)
+	fetched, err := suite.ioctx.GetOmapValues(oid, "", "", 4)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), orig, fetched)
+
+	// Get All (with an iterator size bigger than the map size)
+	fetched, err = suite.ioctx.GetAllOmapValues(oid, "", "", 100)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), orig, fetched)
+
+	// Get All (with an iterator size smaller than the map size)
+	fetched, err = suite.ioctx.GetAllOmapValues(oid, "", "", 1)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), orig, fetched)
+
+	// Remove
+	err = suite.ioctx.RmOmapKeys(oid, []string{"key1", "prefixed-key3"})
+	assert.NoError(suite.T(), err)
+
+	fetched, err = suite.ioctx.GetOmapValues(oid, "", "", 4)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), map[string][]byte{
+		"key2":  []byte("value2"),
+		"empty": []byte(""),
+	}, fetched)
+
+	// Clear
+	err = suite.ioctx.CleanOmap(oid)
+	assert.NoError(suite.T(), err)
+
+	fetched, err = suite.ioctx.GetOmapValues(oid, "", "", 4)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), map[string][]byte{}, fetched)
+}
+
+func (suite *RadosTestSuite) TestReadFilterOmap() {
+	suite.SetupConnection()
+
+	orig := map[string][]byte{
+		"key1":          []byte("value1"),
+		"prefixed-key3": []byte("value3"),
+		"key2":          []byte("value2"),
+	}
+
+	oid := suite.GenObjectName()
+	err := suite.ioctx.SetOmap(oid, orig)
+	assert.NoError(suite.T(), err)
+
+	// filter by prefix
+	fetched, err := suite.ioctx.GetOmapValues(oid, "", "prefixed", 4)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), map[string][]byte{
+		"prefixed-key3": []byte("value3"),
+	}, fetched)
+
+	// "start_after" a key
+	fetched, err = suite.ioctx.GetOmapValues(oid, "key1", "", 4)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), map[string][]byte{
+		"prefixed-key3": []byte("value3"),
+		"key2":          []byte("value2"),
+	}, fetched)
+
+	// maxReturn
+	fetched, err = suite.ioctx.GetOmapValues(oid, "", "key", 1)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), map[string][]byte{
+		"key1": []byte("value1"),
+	}, fetched)
+}
+
+func (suite *RadosTestSuite) TestSetNamespace() {
+	suite.SetupConnection()
+
+	// create oid
+	oid := suite.GenObjectName()
+	bytes_in := []byte("input data")
+	err := suite.ioctx.Write(oid, bytes_in, 0)
+	assert.NoError(suite.T(), err)
+
+	stat, err := suite.ioctx.Stat(oid)
+	assert.Equal(suite.T(), uint64(len(bytes_in)), stat.Size)
+	assert.NotNil(suite.T(), stat.ModTime)
+
+	// oid isn't seen in space1 ns
+	suite.ioctx.SetNamespace("space1")
+	stat, err = suite.ioctx.Stat(oid)
+	assert.Equal(suite.T(), err, ErrNotFound)
+
+	// create oid2 in space1 ns
+	oid2 := suite.GenObjectName()
+	bytes_in = []byte("input data")
+	err = suite.ioctx.Write(oid2, bytes_in, 0)
+	assert.NoError(suite.T(), err)
+
+	suite.ioctx.SetNamespace("")
+	stat, err = suite.ioctx.Stat(oid2)
+	assert.Equal(suite.T(), err, ErrNotFound)
+
+	stat, err = suite.ioctx.Stat(oid)
+	assert.Equal(suite.T(), uint64(len(bytes_in)), stat.Size)
+	assert.NotNil(suite.T(), stat.ModTime)
+}
+
+func (suite *RadosTestSuite) TestListAcrossNamespaces() {
+	suite.SetupConnection()
+
+	// count objects in pool
+	origObjects := 0
+	err := suite.ioctx.ListObjects(func(oid string) {
+		origObjects++
+	})
+
+	// create oid
+	oid := suite.GenObjectName()
+	bytes_in := []byte("input data")
+	err = suite.ioctx.Write(oid, bytes_in, 0)
+	assert.NoError(suite.T(), err)
+
+	// create oid2 in space1 ns
+	suite.ioctx.SetNamespace("space1")
+	oid2 := suite.GenObjectName()
+	bytes_in = []byte("input data")
+	err = suite.ioctx.Write(oid2, bytes_in, 0)
+	assert.NoError(suite.T(), err)
+
+	// count objects in space1 ns
+	nsFoundObjects := 0
+	err = suite.ioctx.ListObjects(func(oid string) {
+		nsFoundObjects++
+	})
+	assert.NoError(suite.T(), err)
+	assert.EqualValues(suite.T(), 1, nsFoundObjects)
+
+	// count objects in pool
+	suite.ioctx.SetNamespace(AllNamespaces)
+	allFoundObjects := 0
+	err = suite.ioctx.ListObjects(func(oid string) {
+		allFoundObjects++
+	})
+	assert.NoError(suite.T(), err)
+	assert.EqualValues(suite.T(), (origObjects + 2), allFoundObjects)
+}
+
+func (suite *RadosTestSuite) TestLocking() {
+	suite.SetupConnection()
+
+	oid := suite.GenObjectName()
+
+	// lock ex
+	res, err := suite.ioctx.LockExclusive(oid, "myLock", "myCookie", "this is a test lock", 0, nil)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), 0, res)
+
+	// verify lock ex
+	info, err := suite.ioctx.ListLockers(oid, "myLock")
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), 1, len(info.Clients))
+	assert.Equal(suite.T(), true, info.Exclusive)
+
+	// fail to lock ex again
+	res, err = suite.ioctx.LockExclusive(oid, "myLock", "myCookie", "this is a description", 0, nil)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), -17, res)
+
+	// fail to lock sh
+	res, err = suite.ioctx.LockShared(oid, "myLock", "myCookie", "", "a description", 0, nil)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), -17, res)
+
+	// unlock
+	res, err = suite.ioctx.Unlock(oid, "myLock", "myCookie")
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), 0, res)
+
+	// verify unlock
+	info, err = suite.ioctx.ListLockers(oid, "myLock")
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), 0, len(info.Clients))
+
+	// lock sh
+	res, err = suite.ioctx.LockShared(oid, "myLock", "myCookie", "", "a description", 0, nil)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), 0, res)
+
+	// verify lock sh
+	info, err = suite.ioctx.ListLockers(oid, "myLock")
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), 1, len(info.Clients))
+	assert.Equal(suite.T(), false, info.Exclusive)
+
+	// fail to lock sh again
+	res, err = suite.ioctx.LockExclusive(oid, "myLock", "myCookie", "a description", 0, nil)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), -17, res)
+
+	// fail to lock ex
+	res, err = suite.ioctx.LockExclusive(oid, "myLock", "myCookie", "this is a test lock", 0, nil)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), res, -17)
+
+	// break the lock
+	res, err = suite.ioctx.BreakLock(oid, "myLock", info.Clients[0], "myCookie")
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), 0, res)
+
+	// verify lock broken
+	info, err = suite.ioctx.ListLockers(oid, "myLock")
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), 0, len(info.Clients))
+
+	// lock sh with duration
+	res, err = suite.ioctx.LockShared(oid, "myLock", "myCookie", "", "a description", time.Millisecond, nil)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), 0, res)
+
+	// verify lock sh expired
+	time.Sleep(time.Second)
+	info, err = suite.ioctx.ListLockers(oid, "myLock")
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), 0, len(info.Clients))
+
+	// lock sh with duration
+	res, err = suite.ioctx.LockExclusive(oid, "myLock", "myCookie", "a description", time.Millisecond, nil)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), 0, res)
+
+	// verify lock sh expired
+	time.Sleep(time.Second)
+	info, err = suite.ioctx.ListLockers(oid, "myLock")
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), 0, len(info.Clients))
+}
+
+func (suite *RadosTestSuite) TestOmapOnNonexistentObjectError() {
+	suite.SetupConnection()
+	oid := suite.GenObjectName()
+	_, err := suite.ioctx.GetAllOmapValues(oid, "", "", 100)
+	assert.Equal(suite.T(), err, ErrNotFound)
+}
+
+func (suite *RadosTestSuite) TestOpenIOContextInvalidPool() {
+	ioctx, err := suite.conn.OpenIOContext("cmartel")
+	require.Error(suite.T(), err)
+	require.Nil(suite.T(), ioctx)
+}
+
+func (suite *RadosTestSuite) TestGetLastVersion() {
+	suite.SetupConnection()
+	// NOTE: Reusing the ioctx set up by SetupConnection seems to make this
+	// test flakey. This is possibly be due to the value being "global" to the
+	// ioctx. Thus we create a new ioctx for the subtests.
+
+	suite.T().Run("write", func(t *testing.T) {
+		ioctx, err := suite.conn.OpenIOContext(suite.pool)
+		require.NoError(suite.T(), err)
+		oid := suite.GenObjectName()
+		defer suite.ioctx.Delete(oid)
+
+		v1, _ := ioctx.GetLastVersion()
+
+		err = ioctx.Write(oid, []byte("something to write"), 0)
+		assert.NoError(t, err)
+
+		v2, _ := ioctx.GetLastVersion()
+		assert.NotEqual(t, v1, v2)
+
+		v3, _ := ioctx.GetLastVersion()
+		assert.Equal(t, v2, v3)
+
+		err = ioctx.Write(oid, []byte("something completely different"), 0)
+		assert.NoError(t, err)
+
+		v4, _ := ioctx.GetLastVersion()
+		assert.NotEqual(t, v1, v4)
+		assert.NotEqual(t, v2, v4)
+		assert.NotEqual(t, v3, v4)
+	})
+
+	suite.T().Run("writeAndRead", func(t *testing.T) {
+		ioctx, err := suite.conn.OpenIOContext(suite.pool)
+		require.NoError(suite.T(), err)
+		oid := suite.GenObjectName()
+		defer ioctx.Delete(oid)
+
+		v1, _ := ioctx.GetLastVersion()
+
+		err = ioctx.Write(oid, []byte("presto"), 0)
+		assert.NoError(t, err)
+
+		v2, _ := ioctx.GetLastVersion()
+		assert.NotEqual(t, v1, v2)
+
+		bytes := make([]byte, 1024)
+		_, err = ioctx.Read(oid, bytes, 0)
+		assert.NoError(t, err)
+
+		v3, _ := ioctx.GetLastVersion()
+		assert.Equal(t, v2, v3)
+
+		err = ioctx.Write(oid, []byte("abracadabra"), 0)
+		assert.NoError(t, err)
+
+		v4, _ := ioctx.GetLastVersion()
+		assert.NotEqual(t, v1, v4)
+		assert.NotEqual(t, v2, v4)
+		assert.NotEqual(t, v3, v4)
+
+		_, err = ioctx.Read(oid, bytes, 0)
+		assert.NoError(t, err)
+
+		v5, _ := ioctx.GetLastVersion()
+		assert.Equal(t, v4, v5)
+	})
+
+	suite.T().Run("writeAndReadMultiple", func(t *testing.T) {
+		ioctx, err := suite.conn.OpenIOContext(suite.pool)
+		require.NoError(suite.T(), err)
+
+		oids := make([]string, 5)
+		vers := make([]uint64, 5)
+		for i := 0; i < 5; i++ {
+			oid := suite.GenObjectName()
+			defer ioctx.Delete(oid)
+			err = ioctx.Write(oid, []byte(oid), 0)
+			assert.NoError(t, err)
+
+			oids[i] = oid
+			vers[i], _ = ioctx.GetLastVersion()
+		}
+
+		var v uint64
+		bytes := make([]byte, 1024)
+
+		_, err = ioctx.Read(oids[0], bytes, 0)
+		assert.NoError(t, err)
+		v, _ = ioctx.GetLastVersion()
+		assert.Equal(t, vers[0], v)
+
+		_, err = ioctx.Read(oids[4], bytes, 0)
+		assert.NoError(t, err)
+		v, _ = ioctx.GetLastVersion()
+		assert.Equal(t, vers[4], v)
+
+		_, err = ioctx.Read(oids[1], bytes, 0)
+		assert.NoError(t, err)
+		v, _ = ioctx.GetLastVersion()
+		assert.Equal(t, vers[1], v)
+	})
+
+	suite.T().Run("invalidIOContext", func(t *testing.T) {
+		ioctx := &IOContext{}
+		_, err := ioctx.GetLastVersion()
+		assert.Error(t, err)
+	})
+}
+
+func TestRadosTestSuite(t *testing.T) {
+	suite.Run(t, new(RadosTestSuite))
+}

--- a/vendor/github.com/ceph/go-ceph/rados/snapshot.go
+++ b/vendor/github.com/ceph/go-ceph/rados/snapshot.go
@@ -1,0 +1,189 @@
+package rados
+
+// #cgo LDFLAGS: -lrados
+// #include <stdlib.h>
+// #include <rados/librados.h>
+import "C"
+
+import (
+	"time"
+	"unsafe"
+
+	"github.com/ceph/go-ceph/internal/retry"
+)
+
+// CreateSnap creates a pool-wide snapshot.
+//
+// Implements:
+// int rados_ioctx_snap_create(rados_ioctx_t io, const char *snapname)
+func (ioctx *IOContext) CreateSnap(snapName string) error {
+	if err := ioctx.validate(); err != nil {
+		return err
+	}
+
+	cSnapName := C.CString(snapName)
+	defer C.free(unsafe.Pointer(cSnapName))
+
+	ret := C.rados_ioctx_snap_create(ioctx.ioctx, cSnapName)
+	return getError(ret)
+}
+
+// RemoveSnap deletes the pool snapshot.
+//
+// Implements:
+//  int rados_ioctx_snap_remove(rados_ioctx_t io, const char *snapname)
+func (ioctx *IOContext) RemoveSnap(snapName string) error {
+	if err := ioctx.validate(); err != nil {
+		return err
+	}
+
+	cSnapName := C.CString(snapName)
+	defer C.free(unsafe.Pointer(cSnapName))
+
+	ret := C.rados_ioctx_snap_remove(ioctx.ioctx, cSnapName)
+	return getError(ret)
+}
+
+// SnapID represents the ID of a rados snapshot.
+type SnapID C.rados_snap_t
+
+// LookupSnap returns the ID of a pool snapshot.
+//
+// Implements:
+//  int rados_ioctx_snap_lookup(rados_ioctx_t io, const char *name, rados_snap_t *id)
+func (ioctx *IOContext) LookupSnap(snapName string) (SnapID, error) {
+	var snapID SnapID
+
+	if err := ioctx.validate(); err != nil {
+		return snapID, err
+	}
+
+	cSnapName := C.CString(snapName)
+	defer C.free(unsafe.Pointer(cSnapName))
+
+	ret := C.rados_ioctx_snap_lookup(
+		ioctx.ioctx,
+		cSnapName,
+		(*C.rados_snap_t)(&snapID))
+	return snapID, getError(ret)
+}
+
+// GetSnapName returns the name of a pool snapshot with the given snapshot ID.
+//
+// Implements:
+//  int rados_ioctx_snap_get_name(rados_ioctx_t io, rados_snap_t id, char *name, int maxlen)
+func (ioctx *IOContext) GetSnapName(snapID SnapID) (string, error) {
+	if err := ioctx.validate(); err != nil {
+		return "", err
+	}
+
+	var (
+		buf []byte
+		err error
+	)
+	// range from 1k to 64KiB
+	retry.WithSizes(1024, 1<<16, func(len int) retry.Hint {
+		cLen := C.int(len)
+		buf = make([]byte, cLen)
+		ret := C.rados_ioctx_snap_get_name(
+			ioctx.ioctx,
+			(C.rados_snap_t)(snapID),
+			(*C.char)(unsafe.Pointer(&buf[0])),
+			cLen)
+		err = getError(ret)
+		return retry.Size(int(cLen)).If(err == errRange)
+	})
+
+	if err != nil {
+		return "", err
+	}
+	return C.GoString((*C.char)(unsafe.Pointer(&buf[0]))), nil
+}
+
+// GetSnapStamp returns the time of the pool snapshot creation.
+//
+// Implements:
+//  int rados_ioctx_snap_get_stamp(rados_ioctx_t io, rados_snap_t id, time_t *t)
+func (ioctx *IOContext) GetSnapStamp(snapID SnapID) (time.Time, error) {
+	var cTime C.time_t
+
+	if err := ioctx.validate(); err != nil {
+		return time.Unix(int64(cTime), 0), err
+	}
+
+	ret := C.rados_ioctx_snap_get_stamp(
+		ioctx.ioctx,
+		(C.rados_snap_t)(snapID),
+		&cTime)
+	return time.Unix(int64(cTime), 0), getError(ret)
+}
+
+// ListSnaps returns a slice containing the SnapIDs of existing pool snapshots.
+//
+// Implements:
+//  int rados_ioctx_snap_list(rados_ioctx_t io, rados_snap_t *snaps, int maxlen)
+func (ioctx *IOContext) ListSnaps() ([]SnapID, error) {
+	if err := ioctx.validate(); err != nil {
+		return nil, err
+	}
+
+	var (
+		snapList []SnapID
+		cLen     C.int
+		err      error
+		ret      C.int
+	)
+	retry.WithSizes(100, 1000, func(maxlen int) retry.Hint {
+		cLen = C.int(maxlen)
+		snapList = make([]SnapID, cLen)
+		ret = C.rados_ioctx_snap_list(
+			ioctx.ioctx,
+			(*C.rados_snap_t)(unsafe.Pointer(&snapList[0])),
+			cLen)
+		err = getErrorIfNegative(ret)
+		return retry.Size(int(cLen)).If(err == errRange)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return snapList[:ret], nil
+}
+
+// RollbackSnap rollbacks the object with key oID to the pool snapshot.
+// The contents of the object will be the same as when the snapshot was taken.
+//
+// Implements:
+//  int rados_ioctx_snap_rollback(rados_ioctx_t io, const char *oid, const char *snapname);
+func (ioctx *IOContext) RollbackSnap(oid, snapName string) error {
+	if err := ioctx.validate(); err != nil {
+		return err
+	}
+
+	coid := C.CString(oid)
+	defer C.free(unsafe.Pointer(coid))
+	cSnapName := C.CString(snapName)
+	defer C.free(unsafe.Pointer(cSnapName))
+
+	ret := C.rados_ioctx_snap_rollback(ioctx.ioctx, coid, cSnapName)
+	return getError(ret)
+}
+
+// SnapHead is the representation of LIBRADOS_SNAP_HEAD from librados.
+// SnapHead can be used to reset the IOContext to stop reading from a snapshot.
+const SnapHead = SnapID(C.LIBRADOS_SNAP_HEAD)
+
+// SetReadSnap sets the snapshot from which reads are performed.
+// Subsequent reads will return data as it was at the time of that snapshot.
+// Pass SnapHead for no snapshot (i.e. normal operation).
+//
+// Implements:
+//  void rados_ioctx_snap_set_read(rados_ioctx_t io, rados_snap_t snap);
+func (ioctx *IOContext) SetReadSnap(snapID SnapID) error {
+	if err := ioctx.validate(); err != nil {
+		return err
+	}
+
+	C.rados_ioctx_snap_set_read(ioctx.ioctx, (C.rados_snap_t)(snapID))
+	return nil
+}

--- a/vendor/github.com/ceph/go-ceph/rados/snapshot_test.go
+++ b/vendor/github.com/ceph/go-ceph/rados/snapshot_test.go
@@ -1,0 +1,312 @@
+package rados
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func (suite *RadosTestSuite) TestCreateRemoveSnapshot() {
+	suite.SetupConnection()
+
+	suite.T().Run("invalidIOCtx", func(t *testing.T) {
+		ioctx := &IOContext{}
+		err := ioctx.CreateSnap("someSnap")
+		assert.Error(t, err)
+		err = ioctx.RemoveSnap("someSnap")
+		assert.Error(t, err)
+		assert.Equal(t, err, ErrInvalidIOContext)
+	})
+
+	suite.T().Run("NewSnap", func(t *testing.T) {
+		ioctx, err := suite.conn.OpenIOContext(suite.pool)
+		require.NoError(suite.T(), err)
+
+		snapName := "mySnap"
+		err = ioctx.CreateSnap(snapName)
+		assert.NoError(t, err)
+		err = ioctx.RemoveSnap(snapName)
+		assert.NoError(t, err)
+	})
+
+	suite.T().Run("ExistingSnap", func(t *testing.T) {
+		ioctx, err := suite.conn.OpenIOContext(suite.pool)
+		require.NoError(suite.T(), err)
+
+		snapName := "mySnap"
+		err = ioctx.CreateSnap(snapName)
+		assert.NoError(t, err)
+		defer func() {
+			assert.NoError(t, ioctx.RemoveSnap(snapName))
+		}()
+		err = ioctx.CreateSnap(snapName)
+		assert.Error(t, err)
+	})
+
+	suite.T().Run("NonExistingSnap", func(t *testing.T) {
+		ioctx, err := suite.conn.OpenIOContext(suite.pool)
+		require.NoError(suite.T(), err)
+
+		err = ioctx.RemoveSnap("someSnapName")
+		assert.Error(t, err)
+	})
+
+	// Strangely, this works!!
+	suite.T().Run("EmptySnapNameString", func(t *testing.T) {
+		ioctx, err := suite.conn.OpenIOContext(suite.pool)
+		require.NoError(suite.T(), err)
+
+		err = ioctx.CreateSnap("")
+		assert.NoError(t, err)
+
+		err = ioctx.RemoveSnap("")
+		assert.NoError(t, err)
+	})
+}
+
+func (suite *RadosTestSuite) TestSnapshotIDFunctions() {
+	suite.SetupConnection()
+
+	suite.T().Run("invalidIOCtx", func(t *testing.T) {
+		ioctx := &IOContext{}
+		_, err := ioctx.LookupSnap("")
+		assert.Error(t, err)
+		assert.Equal(t, err, ErrInvalidIOContext)
+
+		var snapID SnapID
+		snapID = 22 // some random number
+		_, err = ioctx.GetSnapName(snapID)
+		assert.Error(t, err)
+		assert.Equal(t, err, ErrInvalidIOContext)
+
+		_, err = ioctx.GetSnapStamp(snapID)
+		assert.Error(t, err)
+		assert.Equal(t, err, ErrInvalidIOContext)
+	})
+
+	// Invalid args
+	suite.T().Run("InvalidArgs", func(t *testing.T) {
+		ioctx, err := suite.conn.OpenIOContext(suite.pool)
+		require.NoError(suite.T(), err)
+
+		err = ioctx.CreateSnap("")
+		assert.NoError(t, err)
+		defer func() {
+			assert.NoError(t, ioctx.RemoveSnap(""))
+		}()
+
+		// Again, this works!!
+		_, err = ioctx.LookupSnap("")
+		assert.NoError(t, err)
+
+		// Non-existing Snap
+		_, err = ioctx.LookupSnap("someSnapName")
+		assert.Error(t, err)
+
+		var snapID SnapID
+		snapID = 22 // some random number
+		_, err = ioctx.GetSnapName(snapID)
+		assert.Error(t, err)
+
+		_, err = ioctx.GetSnapStamp(snapID)
+		assert.Error(t, err)
+	})
+
+	// Valid SnapID operations.
+	suite.T().Run("ValidSnapIDOps", func(t *testing.T) {
+		ioctx, err := suite.conn.OpenIOContext(suite.pool)
+		require.NoError(suite.T(), err)
+
+		snapName := "mySnap"
+		err = ioctx.CreateSnap(snapName)
+		assert.NoError(t, err)
+		defer func() {
+			assert.NoError(t, ioctx.RemoveSnap(snapName))
+		}()
+
+		snapID, err := ioctx.LookupSnap(snapName)
+		assert.NoError(t, err)
+
+		retName, err := ioctx.GetSnapName(snapID)
+		assert.NoError(t, err)
+		assert.Equal(t, snapName, retName)
+
+		_, err = ioctx.GetSnapStamp(snapID)
+		assert.NoError(t, err)
+	})
+}
+
+func (suite *RadosTestSuite) TestListSnapshot() {
+	suite.SetupConnection()
+	ioctx, err := suite.conn.OpenIOContext(suite.pool)
+	require.NoError(suite.T(), err)
+
+	snapName := []string{"snap1", "snap2", "snap3"}
+	err = ioctx.CreateSnap(snapName[0])
+	assert.NoError(suite.T(), err)
+	defer func() {
+		assert.NoError(suite.T(), ioctx.RemoveSnap(snapName[0]))
+	}()
+
+	err = ioctx.CreateSnap(snapName[1])
+	assert.NoError(suite.T(), err)
+	defer func() {
+		assert.NoError(suite.T(), ioctx.RemoveSnap(snapName[1]))
+	}()
+
+	err = ioctx.CreateSnap(snapName[2])
+	assert.NoError(suite.T(), err)
+	defer func() {
+		assert.NoError(suite.T(), ioctx.RemoveSnap(snapName[2]))
+	}()
+
+	suite.T().Run("invalidIOContext", func(t *testing.T) {
+		ioctx := &IOContext{}
+		_, err := ioctx.ListSnaps()
+		assert.Error(t, err)
+		assert.Equal(t, err, ErrInvalidIOContext)
+	})
+
+	snapList, err := ioctx.ListSnaps()
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), snapList)
+
+	listLen := len(snapList)
+
+	suite.T().Run("NumberOfSnapshots", func(t *testing.T) {
+		assert.Equal(t, 3, listLen)
+	})
+
+	suite.T().Run("MatchSnapNamesWithID", func(t *testing.T) {
+		for _, id := range snapList[0 : listLen-1] {
+			retName, err := ioctx.GetSnapName(id)
+			assert.NoError(t, err)
+			assert.NotNil(t, retName)
+			assert.Contains(t, snapName, retName)
+		}
+	})
+}
+
+func (suite *RadosTestSuite) TestRollbackSnapshot() {
+	suite.SetupConnection()
+
+	suite.T().Run("InvalidArgs", func(t *testing.T) {
+		ioctx, err := suite.conn.OpenIOContext(suite.pool)
+		require.NoError(suite.T(), err)
+		oid := suite.GenObjectName()
+		defer suite.ioctx.Delete(oid)
+
+		err = ioctx.RollbackSnap(oid, "someName")
+		assert.Error(t, err)
+
+		err = ioctx.CreateSnap("")
+		assert.NoError(t, err)
+		defer func() {
+			assert.NoError(t, ioctx.RemoveSnap(""))
+		}()
+		err = ioctx.RollbackSnap("someObj", "")
+		assert.NoError(t, err)
+	})
+
+	suite.T().Run("invalidIOContext", func(t *testing.T) {
+		ioctx := &IOContext{}
+		err := ioctx.RollbackSnap("someObj", "someName")
+		assert.Error(t, err)
+		assert.Equal(t, err, ErrInvalidIOContext)
+	})
+
+	suite.T().Run("WriteAndRollback", func(t *testing.T) {
+		ioctx, err := suite.conn.OpenIOContext(suite.pool)
+		require.NoError(suite.T(), err)
+		oid := suite.GenObjectName()
+		defer suite.ioctx.Delete(oid)
+
+		bytesIn := []byte("Harry Potter")
+		err = suite.ioctx.Write(oid, bytesIn, 0)
+		assert.NoError(t, err)
+		// Take snap.
+		err = ioctx.CreateSnap("mySnap")
+		assert.NoError(t, err)
+		defer func() {
+			assert.NoError(t, ioctx.RemoveSnap("mySnap"))
+		}()
+		// Overwrite.
+		bytesOver := []byte("Potter Harry")
+		err = suite.ioctx.Write(oid, bytesOver, 0)
+		assert.NoError(t, err)
+
+		// Before rollback.
+		bytesOut := make([]byte, len(bytesOver))
+		nOut, err := suite.ioctx.Read(oid, bytesOut, 0)
+		assert.NoError(t, err)
+		assert.Equal(t, nOut, len(bytesOver))
+		assert.Equal(t, bytesOver, bytesOut)
+
+		// Rollback.
+		err = ioctx.RollbackSnap(oid, "mySnap")
+		assert.NoError(t, err)
+
+		// After Rollback.
+		nOut, err = suite.ioctx.Read(oid, bytesOut, 0)
+		assert.NoError(t, err)
+		assert.Equal(t, nOut, len(bytesIn))
+		assert.Equal(t, bytesOut, bytesIn)
+	})
+}
+
+func (suite *RadosTestSuite) TestSetReadSnapshot() {
+	suite.SetupConnection()
+	ioctx, err := suite.conn.OpenIOContext(suite.pool)
+	require.NoError(suite.T(), err)
+
+	bytesIn := []byte("The Order of the Phoenix")
+	err = ioctx.Write("obj", bytesIn, 0)
+	assert.NoError(suite.T(), err)
+
+	// Take snap.
+	err = ioctx.CreateSnap("mySnap")
+	assert.NoError(suite.T(), err)
+	defer func() {
+		assert.NoError(suite.T(), ioctx.RemoveSnap("mySnap"))
+	}()
+
+	// Get Snap ID.
+	snapID, err := ioctx.LookupSnap("mySnap")
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), snapID)
+
+	// Overwrite the object.
+	bytesOver := []byte("The Half blood Prince")
+	err = ioctx.Write("obj", bytesOver, 0)
+	assert.NoError(suite.T(), err)
+
+	// Set read to mySnap.
+	err = ioctx.SetReadSnap(snapID)
+	assert.NoError(suite.T(), err)
+
+	// Read the object.
+	bytesOut := make([]byte, len(bytesIn))
+	nOut, err := ioctx.Read("obj", bytesOut, 0)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), nOut, len(bytesIn))
+	assert.Equal(suite.T(), bytesOut, bytesIn)
+
+	// Set read to SnapHead (back to normal).
+	err = ioctx.SetReadSnap(SnapHead)
+	assert.NoError(suite.T(), err)
+
+	// Read the same object.
+	bytesOut = make([]byte, len(bytesOver))
+	nOut, err = ioctx.Read("obj", bytesOut, 0)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), nOut, len(bytesOver))
+	assert.Equal(suite.T(), bytesOut, bytesOver)
+
+	suite.T().Run("invalidIOContext", func(t *testing.T) {
+		ioctx := &IOContext{}
+		err := ioctx.SetReadSnap(SnapHead)
+		assert.Error(t, err)
+		assert.Equal(t, err, ErrInvalidIOContext)
+	})
+}


### PR DESCRIPTION
According to the upstream docs, the version of go-ceph being used by this branch did not officially support Nautilus. We've seen issues with timeouts against Nautilus clusters and initial testing indicates that this helps make the exporter more reliable against that version.