### PR TITLE
luminous: add pool metric unfound_objects_total

### DIFF
--- a/collectors/conn.go
+++ b/collectors/conn.go
@@ -33,6 +33,7 @@ type Conn interface {
 	Shutdown()
 	MonCommand([]byte) ([]byte, string, error)
 	PGCommand([]byte, []byte) ([]byte, string, error)
+	OpenIOContext(string) (*rados.IOContext, error)
 }
 
 // Verify that *rados.Conn implements Conn correctly.
@@ -242,4 +243,12 @@ func (n *NoopConn) PGCommand(pgid, args []byte) ([]byte, string, error) {
 	}
 
 	return []byte(n.output), "", nil
+}
+
+// OpenIOContext always returns a nil rados.IOContext, and "not implemented"
+// error. The OpenIOContext method in the rados package returns a pointer of
+// rados.IOContext that contains an actual C.rados_ioctx_t, which is not
+// available in this NoopConn.
+func (n *NoopConn) OpenIOContext(pool string) (*rados.IOContext, error) {
+	return nil, errors.New("not implemented")
 }


### PR DESCRIPTION
This adds a per-pool metric `unfound_objects_total` for luminous branch.