### PR TITLE
Luminous snaptrim fix

### DIFF
--- a/collectors/health.go
+++ b/collectors/health.go
@@ -1296,6 +1296,10 @@ func (c *ClusterHealthCollector) collect(ch chan<- prometheus.Metric) error {
 		if state == "scrubbing" {
 			val -= *pgStateCounterMap["scrubbing+deep"]
 		}
+		if state == "snaptrim" {
+			val -= *pgStateCounterMap["snaptrim_wait"]
+		}
+
 		gauge.Set(val)
 		if state == "scrubbing+deep" {
 			state = "deep_scrubbing"

--- a/collectors/health_test.go
+++ b/collectors/health_test.go
@@ -333,6 +333,14 @@ $ sudo ceph -s
 			{
 				"state_name": "active+clean+inconsistent",
 				"count": 1
+			},
+			{
+				"state_name": "active+clean+snaptrim",
+				"count": 15
+			},
+			{
+				"state_name": "active+clean+snaptrim_wait",
+				"count": 25
 			}
 		],
 		"num_pgs": 52000
@@ -340,10 +348,12 @@ $ sudo ceph -s
 	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "7 pgs undersized"}]}
 }`,
 			regexes: []*regexp.Regexp{
-				regexp.MustCompile(`active_pgs{cluster="ceph"} 8`),
+				regexp.MustCompile(`active_pgs{cluster="ceph"} 48`),
 				regexp.MustCompile(`scrubbing_pgs{cluster="ceph"} 2`),
 				regexp.MustCompile(`deep_scrubbing_pgs{cluster="ceph"} 5`),
 				regexp.MustCompile(`inconsistent_pgs{cluster="ceph"} 1`),
+				regexp.MustCompile(`snaptrim_pgs{cluster="ceph"} 15`),
+				regexp.MustCompile(`snaptrim_wait_pgs{cluster="ceph"} 25`),
 			},
 		},
 		{


### PR DESCRIPTION
Guess who has two and a half thumbs and didn't make tests for #198? This guy!

Fixes a bug with snaptrim collection introduced due to `strings.Contains()` usage, where states are `snaptrim+foo`, which matches for both `snaptrim` and `snaptrim_wait`.