### PR TITLE
Normalize ceph-ansible version format

### DIFF
--- a/ceph/version.go
+++ b/ceph/version.go
@@ -17,6 +17,7 @@ package ceph
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -89,6 +90,10 @@ func (version *Version) String() string {
 
 // ParseCephVersion parses the given ceph version string to a *Version or error
 func ParseCephVersion(cephVersion string) (*Version, error) {
+	// standardize ceph-ansible version format
+	var re = regexp.MustCompile(`(\d+\.\d+\.\d+-\d+)\.(.*)`)
+	cephVersion = re.ReplaceAllString(cephVersion, `$1-$2`)
+
 	splitVersion := strings.Split(cephVersion, " ")
 	if len(splitVersion) < 3 {
 		return nil, ErrInvalidVersion

--- a/ceph/version_test.go
+++ b/ceph/version_test.go
@@ -48,6 +48,12 @@ func TestParseCephVersion(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "nautilus-ceph-ansible",
+			args:    args{cephVersion: "ceph version 14.2.11-184.el8cp (44441323476fee97be0ff7a92c6065958c77f1b9) nautilus (stable)"},
+			want:    &Version{Major: 14, Minor: 2, Patch: 11, Revision: 184, Commit: "el8cp"},
+			wantErr: false,
+		},
+		{
 			name:    "octopus",
 			args:    args{cephVersion: "ceph version 15.2.0-1-gcc1e126"},
 			want:    &Version{Major: 15, Minor: 2, Patch: 0, Revision: 1, Commit: "gcc1e126"},


### PR DESCRIPTION
On a cluster installed via `ceph-ansible` the version format is in the form of `xx.xx.xx-yy.zz` instead of the format checked by the exporter `xx.xx.xx-yy-zz` which causes the exporter to fail early. 

This change converts the `ceph-ansible` format to the expected one so it's parsed using the same logic.