### PR TITLE
Replaces gauges with constmetrics

### DIFF
--- a/ceph/health.go
+++ b/ceph/health.go
@@ -188,7 +188,7 @@ type ClusterHealthCollector struct {
 	// Objects show the total no. of RADOS objects that are currently allocated
 	Objects *prometheus.Desc
 
-	// OSDMapFlags
+	// OSDMapFlags - **these are being deprecated in favor of using the OSDMapFlags ConstMetrics descriptor**
 	OSDMapFlagFull        prometheus.Gauge
 	OSDMapFlagPauseRd     prometheus.Gauge
 	OSDMapFlagPauseWr     prometheus.Gauge

--- a/ceph/health.go
+++ b/ceph/health.go
@@ -60,7 +60,7 @@ type ClusterHealthCollector struct {
 	// HealthStatusInterpreter shows the overall health status of a given
 	// cluster, with a breakdown of the HEALTH_WARN status into two groups
 	// based on criticality.
-	HealthStatusInterpreter *prometheus.Desc
+	HealthStatusInterpreter prometheus.Gauge
 
 	// MONsDown show the no. of Monitor that are int DOWN state
 	MONsDown *prometheus.Desc
@@ -367,26 +367,34 @@ func NewClusterHealthCollector(exporter *Exporter) *ClusterHealthCollector {
 			"TOO_FEW_PGS":                          1,
 			"TOO_MANY_PGS":                         1},
 
-		HealthStatus:            prometheus.NewDesc(fmt.Sprintf("%s_health_status", cephNamespace), "Health status of Cluster, can vary only between 3 states (err:2, warn:1, ok:0)", nil, labels),
-		HealthStatusInterpreter: prometheus.NewDesc(fmt.Sprintf("%s_health_status_interp", cephNamespace), "Health status of Cluster, can vary only between 4 states (err:3, critical_warn:2, soft_warn:1, ok:0)", nil, labels),
-		MONsDown:                prometheus.NewDesc(fmt.Sprintf("%s_mons_down", cephNamespace), "Count of Mons that are in DOWN state", nil, labels),
-		TotalPGs:                prometheus.NewDesc(fmt.Sprintf("%s_total_pgs", cephNamespace), "Total no. of PGs in the cluster", nil, labels),
-		PGState:                 prometheus.NewDesc(fmt.Sprintf("%s_pg_state", cephNamespace), "State of PGs in the cluster", []string{"state"}, labels),
-		ActivePGs:               prometheus.NewDesc(fmt.Sprintf("%s_active_pgs", cephNamespace), "No. of active PGs in the cluster", nil, labels),
-		ScrubbingPGs:            prometheus.NewDesc(fmt.Sprintf("%s_scrubbing_pgs", cephNamespace), "No. of scrubbing PGs in the cluster", nil, labels),
-		DeepScrubbingPGs:        prometheus.NewDesc(fmt.Sprintf("%s_deep_scrubbing_pgs", cephNamespace), "No. of deep scrubbing PGs in the cluster", nil, labels),
-		RecoveringPGs:           prometheus.NewDesc(fmt.Sprintf("%s_recovering_pgs", cephNamespace), "No. of recovering PGs in the cluster", nil, labels),
-		RecoveryWaitPGs:         prometheus.NewDesc(fmt.Sprintf("%s_recovery_wait_pgs", cephNamespace), "No. of PGs in the cluster with recovery_wait state", nil, labels),
-		BackfillingPGs:          prometheus.NewDesc(fmt.Sprintf("%s_backfilling_pgs", cephNamespace), "No. of backfilling PGs in the cluster", nil, labels),
-		BackfillWaitPGs:         prometheus.NewDesc(fmt.Sprintf("%s_backfill_wait_pgs", cephNamespace), "No. of PGs in the cluster with backfill_wait state", nil, labels),
-		ForcedRecoveryPGs:       prometheus.NewDesc(fmt.Sprintf("%s_forced_recovery_pgs", cephNamespace), "No. of PGs in the cluster with forced_recovery state", nil, labels),
-		ForcedBackfillPGs:       prometheus.NewDesc(fmt.Sprintf("%s_forced_backfill_pgs", cephNamespace), "No. of PGs in the cluster with forced_backfill state", nil, labels),
-		DownPGs:                 prometheus.NewDesc(fmt.Sprintf("%s_down_pgs", cephNamespace), "No. of PGs in the cluster in down state", nil, labels),
-		IncompletePGs:           prometheus.NewDesc(fmt.Sprintf("%s_incomplete_pgs", cephNamespace), "No. of PGs in the cluster in incomplete state", nil, labels),
-		InconsistentPGs:         prometheus.NewDesc(fmt.Sprintf("%s_inconsistent_pgs", cephNamespace), "No. of PGs in the cluster in inconsistent state", nil, labels),
-		SnaptrimPGs:             prometheus.NewDesc(fmt.Sprintf("%s_snaptrim_pgs", cephNamespace), "No. of snaptrim PGs in the cluster", nil, labels),
-		SnaptrimWaitPGs:         prometheus.NewDesc(fmt.Sprintf("%s_snaptrim_wait_pgs", cephNamespace), "No. of PGs in the cluster with snaptrim_wait state", nil, labels),
-		RepairingPGs:            prometheus.NewDesc(fmt.Sprintf("%s_repairing_pgs", cephNamespace), "No. of PGs in the cluster with repair state", nil, labels),
+		HealthStatus: prometheus.NewDesc(fmt.Sprintf("%s_health_status", cephNamespace), "Health status of Cluster, can vary only between 3 states (err:2, warn:1, ok:0)", nil, labels),
+		//HealthStatusInterpreter: prometheus.NewDesc(fmt.Sprintf("%s_health_status_interp", cephNamespace), "Health status of Cluster, can vary only between 4 states (err:3, critical_warn:2, soft_warn:1, ok:0)", nil, labels),
+		HealthStatusInterpreter: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace:   cephNamespace,
+				Name:        "health_status_interp",
+				Help:        "Health status of Cluster, can vary only between 4 states (err:3, critical_warn:2, soft_warn:1, ok:0)",
+				ConstLabels: labels,
+			},
+		),
+		MONsDown:          prometheus.NewDesc(fmt.Sprintf("%s_mons_down", cephNamespace), "Count of Mons that are in DOWN state", nil, labels),
+		TotalPGs:          prometheus.NewDesc(fmt.Sprintf("%s_total_pgs", cephNamespace), "Total no. of PGs in the cluster", nil, labels),
+		PGState:           prometheus.NewDesc(fmt.Sprintf("%s_pg_state", cephNamespace), "State of PGs in the cluster", []string{"state"}, labels),
+		ActivePGs:         prometheus.NewDesc(fmt.Sprintf("%s_active_pgs", cephNamespace), "No. of active PGs in the cluster", nil, labels),
+		ScrubbingPGs:      prometheus.NewDesc(fmt.Sprintf("%s_scrubbing_pgs", cephNamespace), "No. of scrubbing PGs in the cluster", nil, labels),
+		DeepScrubbingPGs:  prometheus.NewDesc(fmt.Sprintf("%s_deep_scrubbing_pgs", cephNamespace), "No. of deep scrubbing PGs in the cluster", nil, labels),
+		RecoveringPGs:     prometheus.NewDesc(fmt.Sprintf("%s_recovering_pgs", cephNamespace), "No. of recovering PGs in the cluster", nil, labels),
+		RecoveryWaitPGs:   prometheus.NewDesc(fmt.Sprintf("%s_recovery_wait_pgs", cephNamespace), "No. of PGs in the cluster with recovery_wait state", nil, labels),
+		BackfillingPGs:    prometheus.NewDesc(fmt.Sprintf("%s_backfilling_pgs", cephNamespace), "No. of backfilling PGs in the cluster", nil, labels),
+		BackfillWaitPGs:   prometheus.NewDesc(fmt.Sprintf("%s_backfill_wait_pgs", cephNamespace), "No. of PGs in the cluster with backfill_wait state", nil, labels),
+		ForcedRecoveryPGs: prometheus.NewDesc(fmt.Sprintf("%s_forced_recovery_pgs", cephNamespace), "No. of PGs in the cluster with forced_recovery state", nil, labels),
+		ForcedBackfillPGs: prometheus.NewDesc(fmt.Sprintf("%s_forced_backfill_pgs", cephNamespace), "No. of PGs in the cluster with forced_backfill state", nil, labels),
+		DownPGs:           prometheus.NewDesc(fmt.Sprintf("%s_down_pgs", cephNamespace), "No. of PGs in the cluster in down state", nil, labels),
+		IncompletePGs:     prometheus.NewDesc(fmt.Sprintf("%s_incomplete_pgs", cephNamespace), "No. of PGs in the cluster in incomplete state", nil, labels),
+		InconsistentPGs:   prometheus.NewDesc(fmt.Sprintf("%s_inconsistent_pgs", cephNamespace), "No. of PGs in the cluster in inconsistent state", nil, labels),
+		SnaptrimPGs:       prometheus.NewDesc(fmt.Sprintf("%s_snaptrim_pgs", cephNamespace), "No. of snaptrim PGs in the cluster", nil, labels),
+		SnaptrimWaitPGs:   prometheus.NewDesc(fmt.Sprintf("%s_snaptrim_wait_pgs", cephNamespace), "No. of PGs in the cluster with snaptrim_wait state", nil, labels),
+		RepairingPGs:      prometheus.NewDesc(fmt.Sprintf("%s_repairing_pgs", cephNamespace), "No. of PGs in the cluster with repair state", nil, labels),
 		// with Nautilus, SLOW_OPS has replaced both REQUEST_SLOW and REQUEST_STUCK
 		// therefore slow_requests is deprecated, but for backwards compatibility
 		// the metric name will be kept the same for the time being
@@ -563,6 +571,8 @@ func NewClusterHealthCollector(exporter *Exporter) *ClusterHealthCollector {
 // collectorsList represents legacy gauges before the migration to constmetrics
 func (c *ClusterHealthCollector) collectorsList() []prometheus.Collector {
 	return []prometheus.Collector{
+		c.HealthStatusInterpreter,
+
 		c.OSDMapFlagFull,
 		c.OSDMapFlagPauseRd,
 		c.OSDMapFlagPauseWr,
@@ -582,7 +592,7 @@ func (c *ClusterHealthCollector) collectorsList() []prometheus.Collector {
 func (c *ClusterHealthCollector) descriptorList() []*prometheus.Desc {
 	return []*prometheus.Desc{
 		c.HealthStatus,
-		c.HealthStatusInterpreter,
+		c.HealthStatusInterpreter.Desc(),
 		c.MONsDown,
 		c.TotalPGs,
 		c.DegradedPGs,
@@ -739,13 +749,17 @@ func (c *ClusterHealthCollector) collect(ch chan<- prometheus.Metric) error {
 	switch stats.Health.Status {
 	case CephHealthOK:
 		ch <- prometheus.MustNewConstMetric(c.HealthStatus, prometheus.GaugeValue, float64(0))
-		ch <- prometheus.MustNewConstMetric(c.HealthStatusInterpreter, prometheus.GaugeValue, float64(0))
+		c.HealthStatusInterpreter.Set(float64(0))
+		// migration of HealthStatusInterpreter to ConstMetrics had to be reverted due to duplication issues with the current structure (and labels not being used)
+		//ch <- prometheus.MustNewConstMetric(c.HealthStatusInterpreter, prometheus.GaugeValue, float64(0))
 	case CephHealthWarn:
 		ch <- prometheus.MustNewConstMetric(c.HealthStatus, prometheus.GaugeValue, float64(1))
-		ch <- prometheus.MustNewConstMetric(c.HealthStatusInterpreter, prometheus.GaugeValue, float64(2))
+		c.HealthStatusInterpreter.Set(float64(2))
+		//ch <- prometheus.MustNewConstMetric(c.HealthStatusInterpreter, prometheus.GaugeValue, float64(2))
 	case CephHealthErr:
 		ch <- prometheus.MustNewConstMetric(c.HealthStatus, prometheus.GaugeValue, float64(2))
-		ch <- prometheus.MustNewConstMetric(c.HealthStatusInterpreter, prometheus.GaugeValue, float64(3))
+		c.HealthStatusInterpreter.Set(float64(3))
+		//ch <- prometheus.MustNewConstMetric(c.HealthStatusInterpreter, prometheus.GaugeValue, float64(3))
 	}
 
 	var (
@@ -871,7 +885,9 @@ func (c *ClusterHealthCollector) collect(ch chan<- prometheus.Metric) error {
 		}
 		if !mapEmpty {
 			if val, present := c.healthChecksMap[k]; present {
-				ch <- prometheus.MustNewConstMetric(c.HealthStatusInterpreter, prometheus.GaugeValue, float64(val))
+				c.HealthStatusInterpreter.Set(float64(val))
+				// migration of HealthStatusInterpreter to ConstMetrics had to be reverted due to duplication issues with the current structure (and labels not being used)
+				//ch <- prometheus.MustNewConstMetric(c.HealthStatusInterpreter, prometheus.GaugeValue, float64(val))
 			}
 		}
 	}

--- a/ceph/health.go
+++ b/ceph/health.go
@@ -55,138 +55,138 @@ type ClusterHealthCollector struct {
 	healthChecksMap map[string]int
 
 	// HealthStatus shows the overall health status of a given cluster.
-	HealthStatus prometheus.Gauge
+	HealthStatus *prometheus.Desc
 
 	// HealthStatusInterpreter shows the overall health status of a given
 	// cluster, with a breakdown of the HEALTH_WARN status into two groups
 	// based on criticality.
-	HealthStatusInterpreter prometheus.Gauge
+	HealthStatusInterpreter *prometheus.Desc
 
 	// MONsDown show the no. of Monitor that are int DOWN state
-	MONsDown prometheus.Gauge
+	MONsDown *prometheus.Desc
 
 	// TotalPGs shows the total no. of PGs the cluster constitutes of.
-	TotalPGs prometheus.Gauge
+	TotalPGs *prometheus.Desc
 
 	// PGstate contains state of all PGs labelled with the name of states.
-	PGState *prometheus.GaugeVec
+	PGState *prometheus.Desc
 
 	// ActivePGs shows the no. of PGs the cluster is actively serving data
 	// from.
-	ActivePGs prometheus.Gauge
+	ActivePGs *prometheus.Desc
 
 	// DegradedPGs shows the no. of PGs that have some of the replicas
 	// missing.
-	DegradedPGs prometheus.Gauge
+	DegradedPGs *prometheus.Desc
 
 	// StuckDegradedPGs shows the no. of PGs that have some of the replicas
 	// missing, and are stuck in that state.
-	StuckDegradedPGs prometheus.Gauge
+	StuckDegradedPGs *prometheus.Desc
 
 	// UncleanPGs shows the no. of PGs that do not have all objects in the PG
 	// that are supposed to be in it.
-	UncleanPGs prometheus.Gauge
+	UncleanPGs *prometheus.Desc
 
 	// StuckUncleanPGs shows the no. of PGs that do not have all objects in the PG
 	// that are supposed to be in it, and are stuck in that state.
-	StuckUncleanPGs prometheus.Gauge
+	StuckUncleanPGs *prometheus.Desc
 
 	// UndersizedPGs depicts the no. of PGs that have fewer copies than configured
 	// replication level.
-	UndersizedPGs prometheus.Gauge
+	UndersizedPGs *prometheus.Desc
 
 	// StuckUndersizedPGs depicts the no. of PGs that have fewer copies than configured
 	// replication level, and are stuck in that state.
-	StuckUndersizedPGs prometheus.Gauge
+	StuckUndersizedPGs *prometheus.Desc
 
 	// StalePGs depicts no. of PGs that are in an unknown state i.e. monitors do not know
 	// anything about their latest state since their pg mapping was modified.
-	StalePGs prometheus.Gauge
+	StalePGs *prometheus.Desc
 
 	// StuckStalePGs depicts no. of PGs that are in an unknown state i.e. monitors do not know
 	// anything about their latest state since their pg mapping was modified, and are stuck
 	// in that state.
-	StuckStalePGs prometheus.Gauge
+	StuckStalePGs *prometheus.Desc
 
 	// PeeringPGs depicts no. of PGs that have one or more OSDs undergo state changes
 	// that need to be communicated to the remaining peers.
-	PeeringPGs prometheus.Gauge
+	PeeringPGs *prometheus.Desc
 
 	// ScrubbingPGs depicts no. of PGs that are in scrubbing state.
 	// Light scrubbing checks the object size and attributes.
-	ScrubbingPGs prometheus.Gauge
+	ScrubbingPGs *prometheus.Desc
 
 	// DeepScrubbingPGs depicts no. of PGs that are in scrubbing+deep state.
 	// Deep scrubbing reads the data and uses checksums to ensure data integrity.
-	DeepScrubbingPGs prometheus.Gauge
+	DeepScrubbingPGs *prometheus.Desc
 
 	// RecoveringPGs depicts no. of PGs that are in recovering state.
 	// The PGs in this state have been dequeued from recovery_wait queue and are
 	// actively undergoing recovery.
-	RecoveringPGs prometheus.Gauge
+	RecoveringPGs *prometheus.Desc
 
 	// RecoveryWaitPGs depicts no. of PGs that are in recovery_wait state.
 	// The PGs in this state are still in queue to start recovery on them.
-	RecoveryWaitPGs prometheus.Gauge
+	RecoveryWaitPGs *prometheus.Desc
 
 	// BackfillingPGs depicts no. of PGs that are in backfilling state.
 	// The PGs in this state have been dequeued from backfill_wait queue and are
 	// actively undergoing recovery.
-	BackfillingPGs prometheus.Gauge
+	BackfillingPGs *prometheus.Desc
 
 	// BackfillWaitPGs depicts no. of PGs that are in backfill_wait state.
 	// The PGs in this state are still in queue to start backfill on them.
-	BackfillWaitPGs prometheus.Gauge
+	BackfillWaitPGs *prometheus.Desc
 
 	// ForcedRecoveryPGs depicts no. of PGs that are undergoing forced recovery.
-	ForcedRecoveryPGs prometheus.Gauge
+	ForcedRecoveryPGs *prometheus.Desc
 
 	// ForcedBackfillPGs depicts no. of PGs that are undergoing forced backfill.
-	ForcedBackfillPGs prometheus.Gauge
+	ForcedBackfillPGs *prometheus.Desc
 
 	// DownPGs depicts no. of PGs that are currently down and not able to serve traffic.
-	DownPGs prometheus.Gauge
+	DownPGs *prometheus.Desc
 
 	// IncompletePGs depicts no. of PGs that are currently incomplete and not able to serve traffic.
-	IncompletePGs prometheus.Gauge
+	IncompletePGs *prometheus.Desc
 
 	// InconsistentPGs depicts no. of PGs that are currently inconsistent
-	InconsistentPGs prometheus.Gauge
+	InconsistentPGs *prometheus.Desc
 
 	// SnaptrimPGs depicts no. of PGs that are currently snaptrimming
-	SnaptrimPGs prometheus.Gauge
+	SnaptrimPGs *prometheus.Desc
 
 	// SnaptrimWaitPGs depicts no. of PGs that are currently waiting to snaptrim
-	SnaptrimWaitPGs prometheus.Gauge
+	SnaptrimWaitPGs *prometheus.Desc
 
 	// RepairingPGs depicts no. of PGs that are currently repairing
-	RepairingPGs prometheus.Gauge
+	RepairingPGs *prometheus.Desc
 
 	// SlowOps depicts no. of total slow ops in the cluster
-	SlowOps prometheus.Gauge
+	SlowOps *prometheus.Desc
 
 	// DegradedObjectsCount gives the no. of RADOS objects are constitute the degraded PGs.
 	// This includes object replicas in its count.
-	DegradedObjectsCount prometheus.Gauge
+	DegradedObjectsCount *prometheus.Desc
 
 	// MisplacedObjectsCount gives the no. of RADOS objects that constitute the misplaced PGs.
 	// Misplaced PGs usually represent the PGs that are not in the storage locations that
 	// they should be in. This is different than degraded PGs which means a PG has fewer copies
 	// that it should.
 	// This includes object replicas in its count.
-	MisplacedObjectsCount prometheus.Gauge
+	MisplacedObjectsCount *prometheus.Desc
 
 	// MisplacedRatio shows the ratio of misplaced objects to total objects
-	MisplacedRatio prometheus.Gauge
+	MisplacedRatio *prometheus.Desc
 
 	// NewCrashReportCount reports if new Ceph daemon crash reports are available
-	NewCrashReportCount prometheus.Gauge
+	NewCrashReportCount *prometheus.Desc
 
 	// TooManyRepairs reports the number of OSDs exceeding mon_osd_warn_num_repaired
-	TooManyRepairs prometheus.Gauge
+	TooManyRepairs *prometheus.Desc
 
 	// Objects show the total no. of RADOS objects that are currently allocated
-	Objects prometheus.Gauge
+	Objects *prometheus.Desc
 
 	// OSDMapFlags
 	OSDMapFlagFull        prometheus.Gauge
@@ -204,60 +204,60 @@ type ClusterHealthCollector struct {
 	OSDMapFlagNoTierAgent prometheus.Gauge
 
 	// OSDsDown show the no. of OSDs that are in the DOWN state.
-	OSDsDown prometheus.Gauge
+	OSDsDown *prometheus.Desc
 
 	// OSDsUp show the no. of OSDs that are in the UP state and are able to serve requests.
-	OSDsUp prometheus.Gauge
+	OSDsUp *prometheus.Desc
 
 	// OSDsIn shows the no. of OSDs that are marked as IN in the cluster.
-	OSDsIn prometheus.Gauge
+	OSDsIn *prometheus.Desc
 
 	// OSDsNum shows the no. of total OSDs the cluster has.
-	OSDsNum prometheus.Gauge
+	OSDsNum *prometheus.Desc
 
 	// RemappedPGs show the no. of PGs that are currently remapped and needs to be moved
 	// to newer OSDs.
-	RemappedPGs prometheus.Gauge
+	RemappedPGs *prometheus.Desc
 
 	// RecoveryIORate shows the i/o rate at which the cluster is performing its ongoing
 	// recovery at.
-	RecoveryIORate prometheus.Gauge
+	RecoveryIORate *prometheus.Desc
 
 	// RecoveryIOKeys shows the rate of rados keys recovery.
-	RecoveryIOKeys prometheus.Gauge
+	RecoveryIOKeys *prometheus.Desc
 
 	// RecoveryIOObjects shows the rate of rados objects being recovered.
-	RecoveryIOObjects prometheus.Gauge
+	RecoveryIOObjects *prometheus.Desc
 
 	// ClientReadBytesPerSec shows the total client read i/o on the cluster.
-	ClientReadBytesPerSec prometheus.Gauge
+	ClientReadBytesPerSec *prometheus.Desc
 
 	// ClientWriteBytesPerSec shows the total client write i/o on the cluster.
-	ClientWriteBytesPerSec prometheus.Gauge
+	ClientWriteBytesPerSec *prometheus.Desc
 
 	// ClientIOOps shows the rate of total operations conducted by all clients on the cluster.
-	ClientIOOps prometheus.Gauge
+	ClientIOOps *prometheus.Desc
 
 	// ClientIOReadOps shows the rate of total read operations conducted by all clients on the cluster.
-	ClientIOReadOps prometheus.Gauge
+	ClientIOReadOps *prometheus.Desc
 
 	// ClientIOWriteOps shows the rate of total write operations conducted by all clients on the cluster.
-	ClientIOWriteOps prometheus.Gauge
+	ClientIOWriteOps *prometheus.Desc
 
 	// CacheFlushIORate shows the i/o rate at which data is being flushed from the cache pool.
-	CacheFlushIORate prometheus.Gauge
+	CacheFlushIORate *prometheus.Desc
 
 	// CacheEvictIORate shows the i/o rate at which data is being flushed from the cache pool.
-	CacheEvictIORate prometheus.Gauge
+	CacheEvictIORate *prometheus.Desc
 
 	// CachePromoteIOOps shows the rate of operations promoting objects to the cache pool.
-	CachePromoteIOOps prometheus.Gauge
+	CachePromoteIOOps *prometheus.Desc
 
 	// MgrsActive shows the number of active mgrs, can be either 0 or 1.
-	MgrsActive prometheus.Gauge
+	MgrsActive *prometheus.Desc
 
 	// MgrsNum shows the total number of mgrs, including standbys.
-	MgrsNum prometheus.Gauge
+	MgrsNum *prometheus.Desc
 
 	// RbdMirrorUp shows the alive rbd-mirror daemons
 	RbdMirrorUp *prometheus.Desc
@@ -362,298 +362,45 @@ func NewClusterHealthCollector(exporter *Exporter) *ClusterHealthCollector {
 			"TOO_FEW_PGS":                          1,
 			"TOO_MANY_PGS":                         1},
 
-		HealthStatus: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "health_status",
-				Help:        "Health status of Cluster, can vary only between 3 states (err:2, warn:1, ok:0)",
-				ConstLabels: labels,
-			},
-		),
-		HealthStatusInterpreter: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "health_status_interp",
-				Help:        "Health status of Cluster, can vary only between 4 states (err:3, critical_warn:2, soft_warn:1, ok:0)",
-				ConstLabels: labels,
-			},
-		),
-		MONsDown: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "mons_down",
-				Help:        "Count of Mons that are in DOWN state",
-				ConstLabels: labels,
-			},
-		),
-		TotalPGs: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "total_pgs",
-				Help:        "Total no. of PGs in the cluster",
-				ConstLabels: labels,
-			},
-		),
-		PGState: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "pg_state",
-				Help:        "State of PGs in the cluster",
-				ConstLabels: labels,
-			},
-			[]string{"state"},
-		),
-		ActivePGs: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "active_pgs",
-				Help:        "No. of active PGs in the cluster",
-				ConstLabels: labels,
-			},
-		),
-		ScrubbingPGs: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "scrubbing_pgs",
-				Help:        "No. of scrubbing PGs in the cluster",
-				ConstLabels: labels,
-			},
-		),
-		DeepScrubbingPGs: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "deep_scrubbing_pgs",
-				Help:        "No. of deep scrubbing PGs in the cluster",
-				ConstLabels: labels,
-			},
-		),
-		RecoveringPGs: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "recovering_pgs",
-				Help:        "No. of recovering PGs in the cluster",
-				ConstLabels: labels,
-			},
-		),
-		RecoveryWaitPGs: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "recovery_wait_pgs",
-				Help:        "No. of PGs in the cluster with recovery_wait state",
-				ConstLabels: labels,
-			},
-		),
-		BackfillingPGs: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "backfilling_pgs",
-				Help:        "No. of backfilling PGs in the cluster",
-				ConstLabels: labels,
-			},
-		),
-		BackfillWaitPGs: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "backfill_wait_pgs",
-				Help:        "No. of PGs in the cluster with backfill_wait state",
-				ConstLabels: labels,
-			},
-		),
-		ForcedRecoveryPGs: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "forced_recovery_pgs",
-				Help:        "No. of PGs in the cluster with forced_recovery state",
-				ConstLabels: labels,
-			},
-		),
-		ForcedBackfillPGs: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "forced_backfill_pgs",
-				Help:        "No. of PGs in the cluster with forced_backfill state",
-				ConstLabels: labels,
-			},
-		),
-		DownPGs: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "down_pgs",
-				Help:        "No. of PGs in the cluster in down state",
-				ConstLabels: labels,
-			},
-		),
-		IncompletePGs: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "incomplete_pgs",
-				Help:        "No. of PGs in the cluster in incomplete state",
-				ConstLabels: labels,
-			},
-		),
-		InconsistentPGs: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "inconsistent_pgs",
-				Help:        "No. of PGs in the cluster in inconsistent state",
-				ConstLabels: labels,
-			},
-		),
-		SnaptrimPGs: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "snaptrim_pgs",
-				Help:        "No. of snaptrim PGs in the cluster",
-				ConstLabels: labels,
-			},
-		),
-		SnaptrimWaitPGs: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "snaptrim_wait_pgs",
-				Help:        "No. of PGs in the cluster with snaptrim_wait state",
-				ConstLabels: labels,
-			},
-		),
-		RepairingPGs: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "repairing_pgs",
-				Help:        "No. of PGs in the cluster with repair state",
-				ConstLabels: labels,
-			},
-		),
+		HealthStatus:            prometheus.NewDesc(fmt.Sprintf("%s_health_status", cephNamespace), "Health status of Cluster, can vary only between 3 states (err:2, warn:1, ok:0)", nil, labels),
+		HealthStatusInterpreter: prometheus.NewDesc(fmt.Sprintf("%s_health_status_interp", cephNamespace), "Health status of Cluster, can vary only between 4 states (err:3, critical_warn:2, soft_warn:1, ok:0)", nil, labels),
+		MONsDown:                prometheus.NewDesc(fmt.Sprintf("%s_mons_down", cephNamespace), "Count of Mons that are in DOWN state", nil, labels),
+		TotalPGs:                prometheus.NewDesc(fmt.Sprintf("%s_total_pgs", cephNamespace), "Total no. of PGs in the cluster", nil, labels),
+		PGState:                 prometheus.NewDesc(fmt.Sprintf("%s_pg_state", cephNamespace), "State of PGs in the cluster", []string{"state"}, labels),
+		ActivePGs:               prometheus.NewDesc(fmt.Sprintf("%s_active_pgs", cephNamespace), "No. of active PGs in the cluster", nil, labels),
+		ScrubbingPGs:            prometheus.NewDesc(fmt.Sprintf("%s_scrubbing_pgs", cephNamespace), "No. of scrubbing PGs in the cluster", nil, labels),
+		DeepScrubbingPGs:        prometheus.NewDesc(fmt.Sprintf("%s_deep_scrubbing_pgs", cephNamespace), "No. of deep scrubbing PGs in the cluster", nil, labels),
+		RecoveringPGs:           prometheus.NewDesc(fmt.Sprintf("%s_recovering_pgs", cephNamespace), "No. of recovering PGs in the cluster", nil, labels),
+		RecoveryWaitPGs:         prometheus.NewDesc(fmt.Sprintf("%s_recovery_wait_pgs", cephNamespace), "No. of PGs in the cluster with recovery_wait state", nil, labels),
+		BackfillingPGs:          prometheus.NewDesc(fmt.Sprintf("%s_backfilling_pgs", cephNamespace), "No. of backfilling PGs in the cluster", nil, labels),
+		BackfillWaitPGs:         prometheus.NewDesc(fmt.Sprintf("%s_backfill_wait_pgs", cephNamespace), "No. of PGs in the cluster with backfill_wait state", nil, labels),
+		ForcedRecoveryPGs:       prometheus.NewDesc(fmt.Sprintf("%s_forced_recovery_pgs", cephNamespace), "No. of PGs in the cluster with forced_recovery state", nil, labels),
+		ForcedBackfillPGs:       prometheus.NewDesc(fmt.Sprintf("%s_forced_backfill_pgs", cephNamespace), "No. of PGs in the cluster with forced_backfill state", nil, labels),
+		DownPGs:                 prometheus.NewDesc(fmt.Sprintf("%s_down_pgs", cephNamespace), "No. of PGs in the cluster in down state", nil, labels),
+		IncompletePGs:           prometheus.NewDesc(fmt.Sprintf("%s_incomplete_pgs", cephNamespace), "No. of PGs in the cluster in incomplete state", nil, labels),
+		InconsistentPGs:         prometheus.NewDesc(fmt.Sprintf("%s_inconsistent_pgs", cephNamespace), "No. of PGs in the cluster in inconsistent state", nil, labels),
+		SnaptrimPGs:             prometheus.NewDesc(fmt.Sprintf("%s_snaptrim_pgs", cephNamespace), "No. of snaptrim PGs in the cluster", nil, labels),
+		SnaptrimWaitPGs:         prometheus.NewDesc(fmt.Sprintf("%s_snaptrim_wait_pgs", cephNamespace), "No. of PGs in the cluster with snaptrim_wait state", nil, labels),
+		RepairingPGs:            prometheus.NewDesc(fmt.Sprintf("%s_repairing_pgs", cephNamespace), "No. of PGs in the cluster with repair state", nil, labels),
 		// with Nautilus, SLOW_OPS has replaced both REQUEST_SLOW and REQUEST_STUCK
 		// therefore slow_requests is deprecated, but for backwards compatibility
 		// the metric name will be kept the same for the time being
-		SlowOps: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "slow_requests",
-				Help:        "No. of slow requests/slow ops",
-				ConstLabels: labels,
-			},
-		),
-		DegradedPGs: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "degraded_pgs",
-				Help:        "No. of PGs in a degraded state",
-				ConstLabels: labels,
-			},
-		),
-		StuckDegradedPGs: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "stuck_degraded_pgs",
-				Help:        "No. of PGs stuck in a degraded state",
-				ConstLabels: labels,
-			},
-		),
-		UncleanPGs: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "unclean_pgs",
-				Help:        "No. of PGs in an unclean state",
-				ConstLabels: labels,
-			},
-		),
-		StuckUncleanPGs: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "stuck_unclean_pgs",
-				Help:        "No. of PGs stuck in an unclean state",
-				ConstLabels: labels,
-			},
-		),
-		UndersizedPGs: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "undersized_pgs",
-				Help:        "No. of undersized PGs in the cluster",
-				ConstLabels: labels,
-			},
-		),
-		StuckUndersizedPGs: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "stuck_undersized_pgs",
-				Help:        "No. of stuck undersized PGs in the cluster",
-				ConstLabels: labels,
-			},
-		),
-		StalePGs: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "stale_pgs",
-				Help:        "No. of stale PGs in the cluster",
-				ConstLabels: labels,
-			},
-		),
-		StuckStalePGs: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "stuck_stale_pgs",
-				Help:        "No. of stuck stale PGs in the cluster",
-				ConstLabels: labels,
-			},
-		),
-		PeeringPGs: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "peering_pgs",
-				Help:        "No. of peering PGs in the cluster",
-				ConstLabels: labels,
-			},
-		),
-		DegradedObjectsCount: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "degraded_objects",
-				Help:        "No. of degraded objects across all PGs, includes replicas",
-				ConstLabels: labels,
-			},
-		),
-		MisplacedObjectsCount: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "misplaced_objects",
-				Help:        "No. of misplaced objects across all PGs, includes replicas",
-				ConstLabels: labels,
-			},
-		),
-		MisplacedRatio: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "misplaced_ratio",
-				Help:        "ratio of misplaced objects to total objects",
-				ConstLabels: labels,
-			},
-		),
-		NewCrashReportCount: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "new_crash_reports",
-				Help:        "Number of new crash reports available",
-				ConstLabels: labels,
-			},
-		),
-		TooManyRepairs: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "osds_too_many_repair",
-				Help:        "Number of OSDs with too many repaired reads",
-				ConstLabels: labels,
-			},
-		),
-		Objects: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "cluster_objects",
-				Help:        "No. of rados objects within the cluster",
-				ConstLabels: labels,
-			},
-		),
+		SlowOps:               prometheus.NewDesc(fmt.Sprintf("%s_slow_requests", cephNamespace), "No. of slow requests/slow ops", nil, labels),
+		DegradedPGs:           prometheus.NewDesc(fmt.Sprintf("%s_degraded_pgs", cephNamespace), "No. of PGs in a degraded state", nil, labels),
+		StuckDegradedPGs:      prometheus.NewDesc(fmt.Sprintf("%s_stuck_degraded_pgs", cephNamespace), "No. of PGs stuck in a degraded state", nil, labels),
+		UncleanPGs:            prometheus.NewDesc(fmt.Sprintf("%s_unclean_pgs", cephNamespace), "No. of PGs in an unclean state", nil, labels),
+		StuckUncleanPGs:       prometheus.NewDesc(fmt.Sprintf("%s_stuck_unclean_pgs", cephNamespace), "No. of PGs stuck in an unclean state", nil, labels),
+		UndersizedPGs:         prometheus.NewDesc(fmt.Sprintf("%s_undersized_pgs", cephNamespace), "No. of undersized PGs in the cluster", nil, labels),
+		StuckUndersizedPGs:    prometheus.NewDesc(fmt.Sprintf("%s_stuck_undersized_pgs", cephNamespace), "No. of stuck undersized PGs in the cluster", nil, labels),
+		StalePGs:              prometheus.NewDesc(fmt.Sprintf("%s_stale_pgs", cephNamespace), "No. of stale PGs in the cluster", nil, labels),
+		StuckStalePGs:         prometheus.NewDesc(fmt.Sprintf("%s_stuck_stale_pgs", cephNamespace), "No. of stuck stale PGs in the cluster", nil, labels),
+		PeeringPGs:            prometheus.NewDesc(fmt.Sprintf("%s_peering_pgs", cephNamespace), "No. of peering PGs in the cluster", nil, labels),
+		DegradedObjectsCount:  prometheus.NewDesc(fmt.Sprintf("%s_degraded_objects", cephNamespace), "No. of degraded objects across all PGs, includes replicas", nil, labels),
+		MisplacedObjectsCount: prometheus.NewDesc(fmt.Sprintf("%s_misplaced_objects", cephNamespace), "No. of misplaced objects across all PGs, includes replicas", nil, labels),
+		MisplacedRatio:        prometheus.NewDesc(fmt.Sprintf("%s_misplaced_ratio", cephNamespace), "ratio of misplaced objects to total objects", nil, labels),
+		NewCrashReportCount:   prometheus.NewDesc(fmt.Sprintf("%s_new_crash_reports", cephNamespace), "Number of new crash reports available", nil, labels),
+		TooManyRepairs:        prometheus.NewDesc(fmt.Sprintf("%s_osds_too_many_repair", cephNamespace), "Number of OSDs with too many repaired reads", nil, labels),
+		Objects:               prometheus.NewDesc(fmt.Sprintf("%s_cluster_objects", cephNamespace), "No. of rados objects within the cluster", nil, labels),
 		OSDMapFlagFull: prometheus.NewGauge(
 			prometheus.GaugeOpts{
 				Namespace:   cephNamespace,
@@ -758,156 +505,25 @@ func NewClusterHealthCollector(exporter *Exporter) *ClusterHealthCollector {
 				ConstLabels: labels,
 			},
 		),
-		OSDsDown: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "osds_down",
-				Help:        "Count of OSDs that are in DOWN state",
-				ConstLabels: labels,
-			},
-		),
-		OSDsUp: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "osds_up",
-				Help:        "Count of OSDs that are in UP state",
-				ConstLabels: labels,
-			},
-		),
-		OSDsIn: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "osds_in",
-				Help:        "Count of OSDs that are in IN state and available to serve requests",
-				ConstLabels: labels,
-			},
-		),
-		OSDsNum: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "osds",
-				Help:        "Count of total OSDs in the cluster",
-				ConstLabels: labels,
-			},
-		),
-		RemappedPGs: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "pgs_remapped",
-				Help:        "No. of PGs that are remapped and incurring cluster-wide movement",
-				ConstLabels: labels,
-			},
-		),
-		RecoveryIORate: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "recovery_io_bytes",
-				Help:        "Rate of bytes being recovered in cluster per second",
-				ConstLabels: labels,
-			},
-		),
-		RecoveryIOKeys: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "recovery_io_keys",
-				Help:        "Rate of keys being recovered in cluster per second",
-				ConstLabels: labels,
-			},
-		),
-		RecoveryIOObjects: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "recovery_io_objects",
-				Help:        "Rate of objects being recovered in cluster per second",
-				ConstLabels: labels,
-			},
-		),
-		ClientReadBytesPerSec: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "client_io_read_bytes",
-				Help:        "Rate of bytes being read by all clients per second",
-				ConstLabels: labels,
-			},
-		),
-		ClientWriteBytesPerSec: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "client_io_write_bytes",
-				Help:        "Rate of bytes being written by all clients per second",
-				ConstLabels: labels,
-			},
-		),
-		ClientIOOps: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "client_io_ops",
-				Help:        "Total client ops on the cluster measured per second",
-				ConstLabels: labels,
-			},
-		),
-		ClientIOReadOps: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "client_io_read_ops",
-				Help:        "Total client read I/O ops on the cluster measured per second",
-				ConstLabels: labels,
-			},
-		),
-		ClientIOWriteOps: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "client_io_write_ops",
-				Help:        "Total client write I/O ops on the cluster measured per second",
-				ConstLabels: labels,
-			},
-		),
-		CacheFlushIORate: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "cache_flush_io_bytes",
-				Help:        "Rate of bytes being flushed from the cache pool per second",
-				ConstLabels: labels,
-			},
-		),
-		CacheEvictIORate: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "cache_evict_io_bytes",
-				Help:        "Rate of bytes being evicted from the cache pool per second",
-				ConstLabels: labels,
-			},
-		),
-		CachePromoteIOOps: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "cache_promote_io_ops",
-				Help:        "Total cache promote operations measured per second",
-				ConstLabels: labels,
-			},
-		),
-		MgrsActive: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "mgrs_active",
-				Help:        "Count of active mgrs, can be either 0 or 1",
-				ConstLabels: labels,
-			},
-		),
-		MgrsNum: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace:   cephNamespace,
-				Name:        "mgrs",
-				Help:        "Total number of mgrs, including standbys",
-				ConstLabels: labels,
-			},
-		),
-		RbdMirrorUp: prometheus.NewDesc(
-			fmt.Sprintf("%s_rbd_mirror_up", cephNamespace),
-			"Alive rbd-mirror daemons",
-			[]string{"name"},
-			labels,
-		),
+		OSDsDown:               prometheus.NewDesc(fmt.Sprintf("%s_osds_down", cephNamespace), "Count of OSDs that are in DOWN state", nil, labels),
+		OSDsUp:                 prometheus.NewDesc(fmt.Sprintf("%s_osds_up", cephNamespace), "Count of OSDs that are in UP state", nil, labels),
+		OSDsIn:                 prometheus.NewDesc(fmt.Sprintf("%s_osds_in", cephNamespace), "Count of OSDs that are in IN state and available to serve requests", nil, labels),
+		OSDsNum:                prometheus.NewDesc(fmt.Sprintf("%s_osds", cephNamespace), "Count of total OSDs in the cluster", nil, labels),
+		RemappedPGs:            prometheus.NewDesc(fmt.Sprintf("%s_pgs_remapped", cephNamespace), "No. of PGs that are remapped and incurring cluster-wide movement", nil, labels),
+		RecoveryIORate:         prometheus.NewDesc(fmt.Sprintf("%s_recovery_io_bytes", cephNamespace), "Rate of bytes being recovered in cluster per second", nil, labels),
+		RecoveryIOKeys:         prometheus.NewDesc(fmt.Sprintf("%s_recovery_io_keys", cephNamespace), "Rate of keys being recovered in cluster per second", nil, labels),
+		RecoveryIOObjects:      prometheus.NewDesc(fmt.Sprintf("%s_recovery_io_objects", cephNamespace), "Rate of objects being recovered in cluster per second", nil, labels),
+		ClientReadBytesPerSec:  prometheus.NewDesc(fmt.Sprintf("%s_client_io_read_bytes", cephNamespace), "Rate of bytes being read by all clients per second", nil, labels),
+		ClientWriteBytesPerSec: prometheus.NewDesc(fmt.Sprintf("%s_client_io_write_bytes", cephNamespace), "Rate of bytes being written by all clients per second", nil, labels),
+		ClientIOOps:            prometheus.NewDesc(fmt.Sprintf("%s_client_io_ops", cephNamespace), "Total client ops on the cluster measured per second", nil, labels),
+		ClientIOReadOps:        prometheus.NewDesc(fmt.Sprintf("%s_client_io_read_ops", cephNamespace), "Total client read I/O ops on the cluster measured per second", nil, labels),
+		ClientIOWriteOps:       prometheus.NewDesc(fmt.Sprintf("%s_client_io_write_ops", cephNamespace), "Total client write I/O ops on the cluster measured per second", nil, labels),
+		CacheFlushIORate:       prometheus.NewDesc(fmt.Sprintf("%s_cache_flush_io_bytes", cephNamespace), "Rate of bytes being flushed from the cache pool per second", nil, labels),
+		CacheEvictIORate:       prometheus.NewDesc(fmt.Sprintf("%s_cache_evict_io_bytes", cephNamespace), "Rate of bytes being evicted from the cache pool per second", nil, labels),
+		CachePromoteIOOps:      prometheus.NewDesc(fmt.Sprintf("%s_cache_promote_io_ops", cephNamespace), "Total cache promote operations measured per second", nil, labels),
+		MgrsActive:             prometheus.NewDesc(fmt.Sprintf("%s_mgrs_active", cephNamespace), "Count of active mgrs, can be either 0 or 1", nil, labels),
+		MgrsNum:                prometheus.NewDesc(fmt.Sprintf("%s_mgrs", cephNamespace), "Total number of mgrs, including standbys", nil, labels),
+		RbdMirrorUp:            prometheus.NewDesc(fmt.Sprintf("%s_rbd_mirror_up", cephNamespace), "Alive rbd-mirror daemons", []string{"name"}, labels),
 	}
 
 	if exporter.Version.IsAtLeast(Pacific) {
@@ -920,8 +536,27 @@ func NewClusterHealthCollector(exporter *Exporter) *ClusterHealthCollector {
 	return collector
 }
 
-func (c *ClusterHealthCollector) metricsList() []prometheus.Metric {
-	return []prometheus.Metric{
+// collectorsList represents legacy gauges before the migration to constmetrics
+func (c *ClusterHealthCollector) collectorsList() []prometheus.Collector {
+	return []prometheus.Collector{
+		c.OSDMapFlagFull,
+		c.OSDMapFlagPauseRd,
+		c.OSDMapFlagPauseWr,
+		c.OSDMapFlagNoUp,
+		c.OSDMapFlagNoDown,
+		c.OSDMapFlagNoIn,
+		c.OSDMapFlagNoOut,
+		c.OSDMapFlagNoBackfill,
+		c.OSDMapFlagNoRecover,
+		c.OSDMapFlagNoRebalance,
+		c.OSDMapFlagNoScrub,
+		c.OSDMapFlagNoDeepScrub,
+		c.OSDMapFlagNoTierAgent,
+	}
+}
+
+func (c *ClusterHealthCollector) descriptorList() []*prometheus.Desc {
+	return []*prometheus.Desc{
 		c.HealthStatus,
 		c.HealthStatusInterpreter,
 		c.MONsDown,
@@ -957,19 +592,19 @@ func (c *ClusterHealthCollector) metricsList() []prometheus.Metric {
 		c.NewCrashReportCount,
 		c.TooManyRepairs,
 		c.Objects,
-		c.OSDMapFlagFull,
-		c.OSDMapFlagPauseRd,
-		c.OSDMapFlagPauseWr,
-		c.OSDMapFlagNoUp,
-		c.OSDMapFlagNoDown,
-		c.OSDMapFlagNoIn,
-		c.OSDMapFlagNoOut,
-		c.OSDMapFlagNoBackfill,
-		c.OSDMapFlagNoRecover,
-		c.OSDMapFlagNoRebalance,
-		c.OSDMapFlagNoScrub,
-		c.OSDMapFlagNoDeepScrub,
-		c.OSDMapFlagNoTierAgent,
+		c.OSDMapFlagFull.Desc(),
+		c.OSDMapFlagPauseRd.Desc(),
+		c.OSDMapFlagPauseWr.Desc(),
+		c.OSDMapFlagNoUp.Desc(),
+		c.OSDMapFlagNoDown.Desc(),
+		c.OSDMapFlagNoIn.Desc(),
+		c.OSDMapFlagNoOut.Desc(),
+		c.OSDMapFlagNoBackfill.Desc(),
+		c.OSDMapFlagNoRecover.Desc(),
+		c.OSDMapFlagNoRebalance.Desc(),
+		c.OSDMapFlagNoScrub.Desc(),
+		c.OSDMapFlagNoDeepScrub.Desc(),
+		c.OSDMapFlagNoTierAgent.Desc(),
 		c.OSDsDown,
 		c.OSDsUp,
 		c.OSDsIn,
@@ -988,11 +623,6 @@ func (c *ClusterHealthCollector) metricsList() []prometheus.Metric {
 		c.CachePromoteIOOps,
 		c.MgrsActive,
 		c.MgrsNum,
-	}
-}
-
-func (c *ClusterHealthCollector) collectorList() []prometheus.Collector {
-	return []prometheus.Collector{
 		c.PGState,
 	}
 }
@@ -1076,7 +706,7 @@ func (c *ClusterHealthCollector) collect(ch chan<- prometheus.Metric) error {
 		return err
 	}
 
-	for _, metric := range c.metricsList() {
+	for _, metric := range c.collectorsList() {
 		if gauge, ok := metric.(prometheus.Gauge); ok {
 			gauge.Set(0)
 		}
@@ -1084,14 +714,14 @@ func (c *ClusterHealthCollector) collect(ch chan<- prometheus.Metric) error {
 
 	switch stats.Health.Status {
 	case CephHealthOK:
-		c.HealthStatus.Set(0)
-		c.HealthStatusInterpreter.Set(0)
+		ch <- prometheus.MustNewConstMetric(c.HealthStatus, prometheus.GaugeValue, float64(0))
+		ch <- prometheus.MustNewConstMetric(c.HealthStatusInterpreter, prometheus.GaugeValue, float64(0))
 	case CephHealthWarn:
-		c.HealthStatus.Set(1)
-		c.HealthStatusInterpreter.Set(2)
+		ch <- prometheus.MustNewConstMetric(c.HealthStatus, prometheus.GaugeValue, float64(1))
+		ch <- prometheus.MustNewConstMetric(c.HealthStatusInterpreter, prometheus.GaugeValue, float64(2))
 	case CephHealthErr:
-		c.HealthStatus.Set(2)
-		c.HealthStatusInterpreter.Set(3)
+		ch <- prometheus.MustNewConstMetric(c.HealthStatus, prometheus.GaugeValue, float64(2))
+		ch <- prometheus.MustNewConstMetric(c.HealthStatusInterpreter, prometheus.GaugeValue, float64(3))
 	}
 
 	var (
@@ -1115,7 +745,7 @@ func (c *ClusterHealthCollector) collect(ch chan<- prometheus.Metric) error {
 			if err != nil {
 				return err
 			}
-			c.StuckDegradedPGs.Set(float64(v))
+			ch <- prometheus.MustNewConstMetric(c.StuckDegradedPGs, prometheus.GaugeValue, float64(v))
 		}
 
 		matched = stuckUncleanRegex.FindStringSubmatch(s.Summary)
@@ -1124,7 +754,7 @@ func (c *ClusterHealthCollector) collect(ch chan<- prometheus.Metric) error {
 			if err != nil {
 				return err
 			}
-			c.StuckUncleanPGs.Set(float64(v))
+			ch <- prometheus.MustNewConstMetric(c.StuckUncleanPGs, prometheus.GaugeValue, float64(v))
 		}
 
 		matched = stuckUndersizedRegex.FindStringSubmatch(s.Summary)
@@ -1133,7 +763,7 @@ func (c *ClusterHealthCollector) collect(ch chan<- prometheus.Metric) error {
 			if err != nil {
 				return err
 			}
-			c.StuckUndersizedPGs.Set(float64(v))
+			ch <- prometheus.MustNewConstMetric(c.StuckUndersizedPGs, prometheus.GaugeValue, float64(v))
 		}
 
 		matched = stuckStaleRegex.FindStringSubmatch(s.Summary)
@@ -1142,7 +772,7 @@ func (c *ClusterHealthCollector) collect(ch chan<- prometheus.Metric) error {
 			if err != nil {
 				return err
 			}
-			c.StuckStalePGs.Set(float64(v))
+			ch <- prometheus.MustNewConstMetric(c.StuckStalePGs, prometheus.GaugeValue, float64(v))
 		}
 
 		matched = slowOpsRegexNautilus.FindStringSubmatch(s.Summary)
@@ -1151,7 +781,7 @@ func (c *ClusterHealthCollector) collect(ch chan<- prometheus.Metric) error {
 			if err != nil {
 				return err
 			}
-			c.SlowOps.Set(float64(v))
+			ch <- prometheus.MustNewConstMetric(c.SlowOps, prometheus.GaugeValue, float64(v))
 		}
 	}
 
@@ -1163,7 +793,7 @@ func (c *ClusterHealthCollector) collect(ch chan<- prometheus.Metric) error {
 				if err != nil {
 					return err
 				}
-				c.MONsDown.Set(float64(v))
+				ch <- prometheus.MustNewConstMetric(c.MONsDown, prometheus.GaugeValue, float64(v))
 			}
 		}
 
@@ -1174,7 +804,7 @@ func (c *ClusterHealthCollector) collect(ch chan<- prometheus.Metric) error {
 				if err != nil {
 					return err
 				}
-				c.SlowOps.Set(float64(v))
+				ch <- prometheus.MustNewConstMetric(c.SlowOps, prometheus.GaugeValue, float64(v))
 			}
 		}
 
@@ -1185,7 +815,7 @@ func (c *ClusterHealthCollector) collect(ch chan<- prometheus.Metric) error {
 				if err != nil {
 					return err
 				}
-				c.NewCrashReportCount.Set(float64(v))
+				ch <- prometheus.MustNewConstMetric(c.NewCrashReportCount, prometheus.GaugeValue, float64(v))
 			}
 		}
 
@@ -1196,7 +826,7 @@ func (c *ClusterHealthCollector) collect(ch chan<- prometheus.Metric) error {
 				if err != nil {
 					return err
 				}
-				c.TooManyRepairs.Set(float64(v))
+				ch <- prometheus.MustNewConstMetric(c.TooManyRepairs, prometheus.GaugeValue, float64(v))
 			}
 		}
 
@@ -1235,10 +865,11 @@ func (c *ClusterHealthCollector) collect(ch chan<- prometheus.Metric) error {
 					}
 				}
 			}
+
 		}
 		if !mapEmpty {
 			if val, present := c.healthChecksMap[k]; present {
-				c.HealthStatusInterpreter.Set(float64(val))
+				ch <- prometheus.MustNewConstMetric(c.HealthStatusInterpreter, prometheus.GaugeValue, float64(val))
 			}
 		}
 	}
@@ -1287,7 +918,7 @@ func (c *ClusterHealthCollector) collect(ch chan<- prometheus.Metric) error {
 			"snaptrim_wait":   &snaptrimWaitPGs,
 			"repair":          &repairingPGs,
 		}
-		pgStateGaugeMap = map[string]prometheus.Gauge{
+		pgStateGaugeMap = map[string]*prometheus.Desc{
 			"degraded":        c.DegradedPGs,
 			"active":          c.ActivePGs,
 			"unclean":         c.UncleanPGs,
@@ -1328,24 +959,25 @@ func (c *ClusterHealthCollector) collect(ch chan<- prometheus.Metric) error {
 			val -= *pgStateCounterMap["snaptrim_wait"]
 		}
 
-		gauge.Set(val)
+		ch <- prometheus.MustNewConstMetric(gauge, prometheus.GaugeValue, val)
+
 		if state == "scrubbing+deep" {
 			state = "deep_scrubbing"
 		}
-		c.PGState.WithLabelValues(state).Set(val)
+		ch <- prometheus.MustNewConstMetric(c.PGState, prometheus.GaugeValue, val, state)
 	}
 
-	c.ClientReadBytesPerSec.Set(stats.PGMap.ReadBytePerSec)
-	c.ClientWriteBytesPerSec.Set(stats.PGMap.WriteBytePerSec)
-	c.ClientIOOps.Set(stats.PGMap.ReadOpPerSec + stats.PGMap.WriteOpPerSec)
-	c.ClientIOReadOps.Set(stats.PGMap.ReadOpPerSec)
-	c.ClientIOWriteOps.Set(stats.PGMap.WriteOpPerSec)
-	c.RecoveryIOKeys.Set(stats.PGMap.RecoveringKeysPerSec)
-	c.RecoveryIOObjects.Set(stats.PGMap.RecoveringObjectsPerSec)
-	c.RecoveryIORate.Set(stats.PGMap.RecoveringBytePerSec)
-	c.CacheEvictIORate.Set(stats.PGMap.CacheEvictBytePerSec)
-	c.CacheFlushIORate.Set(stats.PGMap.CacheFlushBytePerSec)
-	c.CachePromoteIOOps.Set(stats.PGMap.CachePromoteOpPerSec)
+	ch <- prometheus.MustNewConstMetric(c.ClientReadBytesPerSec, prometheus.GaugeValue, stats.PGMap.ReadBytePerSec)
+	ch <- prometheus.MustNewConstMetric(c.ClientWriteBytesPerSec, prometheus.GaugeValue, stats.PGMap.WriteBytePerSec)
+	ch <- prometheus.MustNewConstMetric(c.ClientIOOps, prometheus.GaugeValue, stats.PGMap.ReadOpPerSec+stats.PGMap.WriteOpPerSec)
+	ch <- prometheus.MustNewConstMetric(c.ClientIOReadOps, prometheus.GaugeValue, stats.PGMap.ReadOpPerSec)
+	ch <- prometheus.MustNewConstMetric(c.ClientIOWriteOps, prometheus.GaugeValue, stats.PGMap.WriteOpPerSec)
+	ch <- prometheus.MustNewConstMetric(c.RecoveryIOKeys, prometheus.GaugeValue, stats.PGMap.RecoveringKeysPerSec)
+	ch <- prometheus.MustNewConstMetric(c.RecoveryIOObjects, prometheus.GaugeValue, stats.PGMap.RecoveringObjectsPerSec)
+	ch <- prometheus.MustNewConstMetric(c.RecoveryIORate, prometheus.GaugeValue, stats.PGMap.RecoveringBytePerSec)
+	ch <- prometheus.MustNewConstMetric(c.CacheEvictIORate, prometheus.GaugeValue, stats.PGMap.CacheEvictBytePerSec)
+	ch <- prometheus.MustNewConstMetric(c.CacheFlushIORate, prometheus.GaugeValue, stats.PGMap.CacheFlushBytePerSec)
+	ch <- prometheus.MustNewConstMetric(c.CachePromoteIOOps, prometheus.GaugeValue, stats.PGMap.CachePromoteOpPerSec)
 
 	var actualOsdMap osdMap
 	if c.version.IsAtLeast(Octopus) {
@@ -1370,21 +1002,21 @@ func (c *ClusterHealthCollector) collect(ch chan<- prometheus.Metric) error {
 		}
 	}
 
-	c.OSDsUp.Set(actualOsdMap.NumUpOSDs)
-	c.OSDsIn.Set(actualOsdMap.NumInOSDs)
-	c.OSDsNum.Set(actualOsdMap.NumOSDs)
+	ch <- prometheus.MustNewConstMetric(c.OSDsUp, prometheus.GaugeValue, actualOsdMap.NumUpOSDs)
+	ch <- prometheus.MustNewConstMetric(c.OSDsIn, prometheus.GaugeValue, actualOsdMap.NumInOSDs)
+	ch <- prometheus.MustNewConstMetric(c.OSDsNum, prometheus.GaugeValue, actualOsdMap.NumOSDs)
 
 	// Ceph (until v10.2.3) doesn't expose the value of down OSDs
 	// from its status, which is why we have to compute it ourselves.
-	c.OSDsDown.Set(actualOsdMap.NumOSDs - actualOsdMap.NumUpOSDs)
+	ch <- prometheus.MustNewConstMetric(c.OSDsDown, prometheus.GaugeValue, actualOsdMap.NumOSDs-actualOsdMap.NumUpOSDs)
 
-	c.RemappedPGs.Set(actualOsdMap.NumRemappedPGs)
-	c.TotalPGs.Set(stats.PGMap.NumPGs)
-	c.Objects.Set(stats.PGMap.TotalObjects)
+	ch <- prometheus.MustNewConstMetric(c.RemappedPGs, prometheus.GaugeValue, actualOsdMap.NumRemappedPGs)
+	ch <- prometheus.MustNewConstMetric(c.TotalPGs, prometheus.GaugeValue, stats.PGMap.NumPGs)
+	ch <- prometheus.MustNewConstMetric(c.Objects, prometheus.GaugeValue, stats.PGMap.TotalObjects)
 
-	c.DegradedObjectsCount.Set(stats.PGMap.DegradedObjects)
-	c.MisplacedObjectsCount.Set(stats.PGMap.MisplacedObjects)
-	c.MisplacedRatio.Set(stats.PGMap.MisplacedRatio)
+	ch <- prometheus.MustNewConstMetric(c.DegradedObjectsCount, prometheus.GaugeValue, stats.PGMap.DegradedObjects)
+	ch <- prometheus.MustNewConstMetric(c.MisplacedObjectsCount, prometheus.GaugeValue, stats.PGMap.MisplacedObjects)
+	ch <- prometheus.MustNewConstMetric(c.MisplacedRatio, prometheus.GaugeValue, stats.PGMap.MisplacedRatio)
 
 	activeMgr := 0
 	standByMgrs := 0
@@ -1400,8 +1032,8 @@ func (c *ClusterHealthCollector) collect(ch chan<- prometheus.Metric) error {
 		standByMgrs = len(stats.MgrMap.StandBys)
 	}
 
-	c.MgrsActive.Set(float64(activeMgr))
-	c.MgrsNum.Set(float64(activeMgr + standByMgrs))
+	ch <- prometheus.MustNewConstMetric(c.MgrsActive, prometheus.GaugeValue, float64(activeMgr))
+	ch <- prometheus.MustNewConstMetric(c.MgrsNum, prometheus.GaugeValue, float64(activeMgr+standByMgrs))
 
 	for name, data := range stats.ServiceMap.Services.RbdMirror.Daemons {
 		if name == "summary" {
@@ -1442,7 +1074,7 @@ func (c *ClusterHealthCollector) cephUsageCommand(f format) []byte {
 	return cmd
 }
 
-func (c *ClusterHealthCollector) collectRecoveryClientIO() error {
+func (c *ClusterHealthCollector) collectRecoveryClientIO(ch chan<- prometheus.Metric) error {
 	cmd := c.cephUsageCommand(plainFormat)
 	buf, _, err := c.conn.MonCommand(cmd)
 	if err != nil {
@@ -1466,23 +1098,23 @@ func (c *ClusterHealthCollector) collectRecoveryClientIO() error {
 
 		switch {
 		case strings.HasPrefix(line, "recovery io"):
-			if err := c.collectRecoveryIO(line); err != nil {
+			if err := c.collectRecoveryIO(line, ch); err != nil {
 				return err
 			}
 		case strings.HasPrefix(line, "recovery:"):
-			if err := c.collectRecoveryIO(line); err != nil {
+			if err := c.collectRecoveryIO(line, ch); err != nil {
 				return err
 			}
 		case strings.HasPrefix(line, "client io"):
-			if err := c.collectClientIO(line); err != nil {
+			if err := c.collectClientIO(line, ch); err != nil {
 				return err
 			}
 		case strings.HasPrefix(line, "client:"):
-			if err := c.collectClientIO(line); err != nil {
+			if err := c.collectClientIO(line, ch); err != nil {
 				return err
 			}
 		case strings.HasPrefix(line, "cache io"):
-			if err := c.collectCacheIO(line); err != nil {
+			if err := c.collectCacheIO(line, ch); err != nil {
 				return err
 			}
 		}
@@ -1490,7 +1122,7 @@ func (c *ClusterHealthCollector) collectRecoveryClientIO() error {
 	return nil
 }
 
-func (c *ClusterHealthCollector) collectClientIO(clientStr string) error {
+func (c *ClusterHealthCollector) collectClientIO(clientStr string, ch chan<- prometheus.Metric) error {
 	matched := clientReadBytesPerSecRegex.FindStringSubmatch(clientStr)
 	if len(matched) == 3 {
 		v, err := strconv.Atoi(matched[1])
@@ -1509,7 +1141,7 @@ func (c *ClusterHealthCollector) collectClientIO(clientStr string) error {
 			return fmt.Errorf("can't parse units %q", matched[2])
 		}
 
-		c.ClientReadBytesPerSec.Set(float64(v))
+		ch <- prometheus.MustNewConstMetric(c.ClientReadBytesPerSec, prometheus.GaugeValue, float64(v))
 	}
 
 	matched = clientWriteBytesPerSecRegex.FindStringSubmatch(clientStr)
@@ -1530,7 +1162,7 @@ func (c *ClusterHealthCollector) collectClientIO(clientStr string) error {
 			return fmt.Errorf("can't parse units %q", matched[2])
 		}
 
-		c.ClientWriteBytesPerSec.Set(float64(v))
+		ch <- prometheus.MustNewConstMetric(c.ClientWriteBytesPerSec, prometheus.GaugeValue, float64(v))
 	}
 
 	var clientIOOps float64
@@ -1553,7 +1185,7 @@ func (c *ClusterHealthCollector) collectClientIO(clientStr string) error {
 		}
 
 		ClientIOReadOps = float64(v)
-		c.ClientIOReadOps.Set(ClientIOReadOps)
+		ch <- prometheus.MustNewConstMetric(c.ClientIOReadOps, prometheus.GaugeValue, ClientIOReadOps)
 	}
 
 	matched = clientIOWriteOpsRegex.FindStringSubmatch(clientStr)
@@ -1564,7 +1196,7 @@ func (c *ClusterHealthCollector) collectClientIO(clientStr string) error {
 		}
 
 		ClientIOWriteOps = float64(v)
-		c.ClientIOWriteOps.Set(ClientIOWriteOps)
+		ch <- prometheus.MustNewConstMetric(c.ClientIOWriteOps, prometheus.GaugeValue, ClientIOWriteOps)
 	}
 
 	// In versions older than Jewel, we directly get access to total
@@ -1575,12 +1207,12 @@ func (c *ClusterHealthCollector) collectClientIO(clientStr string) error {
 		clientIOOps = ClientIOReadOps + ClientIOWriteOps
 	}
 
-	c.ClientIOOps.Set(clientIOOps)
+	ch <- prometheus.MustNewConstMetric(c.ClientIOOps, prometheus.GaugeValue, clientIOOps)
 
 	return nil
 }
 
-func (c *ClusterHealthCollector) collectRecoveryIO(recoveryStr string) error {
+func (c *ClusterHealthCollector) collectRecoveryIO(recoveryStr string, ch chan<- prometheus.Metric) error {
 	matched := recoveryIORateRegex.FindStringSubmatch(recoveryStr)
 	if len(matched) == 3 {
 		v, err := strconv.Atoi(matched[1])
@@ -1599,7 +1231,7 @@ func (c *ClusterHealthCollector) collectRecoveryIO(recoveryStr string) error {
 			return fmt.Errorf("can't parse units %q", matched[2])
 		}
 
-		c.RecoveryIORate.Set(float64(v))
+		ch <- prometheus.MustNewConstMetric(c.RecoveryIORate, prometheus.GaugeValue, float64(v))
 	}
 
 	matched = recoveryIOKeysRegex.FindStringSubmatch(recoveryStr)
@@ -1609,7 +1241,7 @@ func (c *ClusterHealthCollector) collectRecoveryIO(recoveryStr string) error {
 			return err
 		}
 
-		c.RecoveryIOKeys.Set(float64(v))
+		ch <- prometheus.MustNewConstMetric(c.RecoveryIOKeys, prometheus.GaugeValue, float64(v))
 	}
 
 	matched = recoveryIOObjectsRegex.FindStringSubmatch(recoveryStr)
@@ -1619,12 +1251,12 @@ func (c *ClusterHealthCollector) collectRecoveryIO(recoveryStr string) error {
 			return err
 		}
 
-		c.RecoveryIOObjects.Set(float64(v))
+		ch <- prometheus.MustNewConstMetric(c.RecoveryIOObjects, prometheus.GaugeValue, float64(v))
 	}
 	return nil
 }
 
-func (c *ClusterHealthCollector) collectCacheIO(clientStr string) error {
+func (c *ClusterHealthCollector) collectCacheIO(clientStr string, ch chan<- prometheus.Metric) error {
 	matched := cacheFlushRateRegex.FindStringSubmatch(clientStr)
 	if len(matched) == 3 {
 		v, err := strconv.Atoi(matched[1])
@@ -1643,7 +1275,7 @@ func (c *ClusterHealthCollector) collectCacheIO(clientStr string) error {
 			return fmt.Errorf("can't parse units %q", matched[2])
 		}
 
-		c.CacheFlushIORate.Set(float64(v))
+		ch <- prometheus.MustNewConstMetric(c.CacheFlushIORate, prometheus.GaugeValue, float64(v))
 	}
 
 	matched = cacheEvictRateRegex.FindStringSubmatch(clientStr)
@@ -1664,7 +1296,7 @@ func (c *ClusterHealthCollector) collectCacheIO(clientStr string) error {
 			return fmt.Errorf("can't parse units %q", matched[2])
 		}
 
-		c.CacheEvictIORate.Set(float64(v))
+		ch <- prometheus.MustNewConstMetric(c.CacheEvictIORate, prometheus.GaugeValue, float64(v))
 	}
 
 	matched = cachePromoteOpsRegex.FindStringSubmatch(clientStr)
@@ -1674,7 +1306,7 @@ func (c *ClusterHealthCollector) collectCacheIO(clientStr string) error {
 			return err
 		}
 
-		c.CachePromoteIOOps.Set(float64(v))
+		ch <- prometheus.MustNewConstMetric(c.CachePromoteIOOps, prometheus.GaugeValue, float64(v))
 	}
 	return nil
 }
@@ -1684,12 +1316,8 @@ func (c *ClusterHealthCollector) collectCacheIO(clientStr string) error {
 func (c *ClusterHealthCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.RbdMirrorUp
 
-	for _, metric := range c.metricsList() {
-		ch <- metric.Desc()
-	}
-
-	for _, metric := range c.collectorList() {
-		metric.Describe(ch)
+	for _, metric := range c.descriptorList() {
+		ch <- metric
 	}
 }
 
@@ -1698,19 +1326,15 @@ func (c *ClusterHealthCollector) Describe(ch chan<- *prometheus.Desc) {
 func (c *ClusterHealthCollector) Collect(ch chan<- prometheus.Metric) {
 	c.logger.Debug("collecting cluster health metrics")
 	if err := c.collect(ch); err != nil {
-		c.logger.WithError(err).Error("error collecting cluster health metrics")
+		c.logger.WithError(err).Error("error collecting cluster health metrics " + err.Error())
 	}
 
 	c.logger.Debug("collecting cluster recovery/client I/O metrics")
-	if err := c.collectRecoveryClientIO(); err != nil {
+	if err := c.collectRecoveryClientIO(ch); err != nil {
 		c.logger.WithError(err).Error("error collecting cluster recovery/client I/O metrics")
 	}
 
-	for _, metric := range c.metricsList() {
-		ch <- metric
-	}
-
-	for _, metric := range c.collectorList() {
+	for _, metric := range c.collectorsList() {
 		metric.Collect(ch)
 	}
 }

--- a/ceph/health_test.go
+++ b/ceph/health_test.go
@@ -509,26 +509,21 @@ $ sudo ceph -s
 				  "OSDMAP_FLAGS": {
 					"severity": "HEALTH_WARN",
 					"summary": {
-						"message": "pauserd,pausewr,noout,noin,norecover,noscrub,notieragent flag(s) set; mon 482f68d873d2 is low on available space"
+						"message": "pauserd,pausewr,noout,noin,norecover,noscrub,notieragent,newhypotheticalcephflag flag(s) set; mon 482f68d873d2 is low on available space"
 					}
 				  }
 				}
 			  }
 			}`,
 			reMatch: []*regexp.Regexp{
-				regexp.MustCompile(`osd_map_flags{cluster="ceph",flag="full"} 0`),
 				regexp.MustCompile(`osd_map_flags{cluster="ceph",flag="pauserd"} 1`),
 				regexp.MustCompile(`osd_map_flags{cluster="ceph",flag="pausewr"} 1`),
-				regexp.MustCompile(`osd_map_flags{cluster="ceph",flag="noup"} 0`),
-				regexp.MustCompile(`osd_map_flags{cluster="ceph",flag="nodown"} 0`),
 				regexp.MustCompile(`osd_map_flags{cluster="ceph",flag="noin"} 1`),
 				regexp.MustCompile(`osd_map_flags{cluster="ceph",flag="noout"} 1`),
-				regexp.MustCompile(`osd_map_flags{cluster="ceph",flag="nobackfill"} 0`),
 				regexp.MustCompile(`osd_map_flags{cluster="ceph",flag="norecover"} 1`),
-				regexp.MustCompile(`osd_map_flags{cluster="ceph",flag="norebalance"} 0`),
 				regexp.MustCompile(`osd_map_flags{cluster="ceph",flag="noscrub"} 1`),
-				regexp.MustCompile(`osd_map_flags{cluster="ceph",flag="nodeep_scrub"} 0`),
 				regexp.MustCompile(`osd_map_flags{cluster="ceph",flag="notieragent"} 1`),
+				regexp.MustCompile(`osd_map_flags{cluster="ceph",flag="newhypotheticalcephflag"} 1`),
 				regexp.MustCompile(`health_status_interp{cluster="ceph"} 1`),
 			},
 		},

--- a/ceph/health_test.go
+++ b/ceph/health_test.go
@@ -501,6 +501,38 @@ $ sudo ceph -s
 			},
 		},
 		{
+			name: "many flags set new osdmap constmetrics filled",
+			input: `
+			{
+			  "health": {
+				"checks": {
+				  "OSDMAP_FLAGS": {
+					"severity": "HEALTH_WARN",
+					"summary": {
+						"message": "pauserd,pausewr,noout,noin,norecover,noscrub,notieragent flag(s) set; mon 482f68d873d2 is low on available space"
+					}
+				  }
+				}
+			  }
+			}`,
+			reMatch: []*regexp.Regexp{
+				regexp.MustCompile(`osd_map_flags{cluster="ceph",flag="full"} 0`),
+				regexp.MustCompile(`osd_map_flags{cluster="ceph",flag="pauserd"} 1`),
+				regexp.MustCompile(`osd_map_flags{cluster="ceph",flag="pausewr"} 1`),
+				regexp.MustCompile(`osd_map_flags{cluster="ceph",flag="noup"} 0`),
+				regexp.MustCompile(`osd_map_flags{cluster="ceph",flag="nodown"} 0`),
+				regexp.MustCompile(`osd_map_flags{cluster="ceph",flag="noin"} 1`),
+				regexp.MustCompile(`osd_map_flags{cluster="ceph",flag="noout"} 1`),
+				regexp.MustCompile(`osd_map_flags{cluster="ceph",flag="nobackfill"} 0`),
+				regexp.MustCompile(`osd_map_flags{cluster="ceph",flag="norecover"} 1`),
+				regexp.MustCompile(`osd_map_flags{cluster="ceph",flag="norebalance"} 0`),
+				regexp.MustCompile(`osd_map_flags{cluster="ceph",flag="noscrub"} 1`),
+				regexp.MustCompile(`osd_map_flags{cluster="ceph",flag="nodeep_scrub"} 0`),
+				regexp.MustCompile(`osd_map_flags{cluster="ceph",flag="notieragent"} 1`),
+				regexp.MustCompile(`health_status_interp{cluster="ceph"} 1`),
+			},
+		},
+		{
 			name: "lots of PG data",
 			input: `
 {

--- a/ceph/health_test.go
+++ b/ceph/health_test.go
@@ -175,49 +175,39 @@ func TestClusterHealthCollector(t *testing.T) {
 			},
 		},
 		{
-			name: "health ok",
-			input: `
-{
-	"health": { "status": "HEALTH_OK" } }`,
+			name:  "health ok",
+			input: `{"health": { "status": "HEALTH_OK" } }`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`health_status{cluster="ceph"} 0`),
 			},
 		},
 		{
-			name: "health warn",
-			input: `
-{
-	"health": { "status": "HEALTH_OK } }`,
+			name:  "health warn",
+			input: `{"health": { "status": "HEALTH_OK" } }`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`health_status{cluster="ceph"} 0`),
 				regexp.MustCompile(`health_status_interp{cluster="ceph"} 0`),
 			},
 		},
 		{
-			name: "health ok 2",
-			input: `
-{
-	"health": { "status": "HEALTH_OK } }`,
+			name:  "health ok 2",
+			input: `{"health": { "status": "HEALTH_OK" } }`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`health_status{cluster="ceph"} 0`),
 				regexp.MustCompile(`health_status_interp{cluster="ceph"} 0`),
 			},
 		},
 		{
-			name: "health warn 2",
-			input: `
-{
-	"health": { "status": "HEALTH_WARN" } }`,
+			name:  "health warn 2",
+			input: `{"health": { "status": "HEALTH_WARN" } }`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`health_status{cluster="ceph"} 1`),
 				regexp.MustCompile(`health_status_interp{cluster="ceph"} 2`),
 			},
 		},
 		{
-			name: "health err",
-			input: `
-{
-	"health": { "status": "HEALTH_ERR" } }`,
+			name:  "health err",
+			input: `{"health": { "status": "HEALTH_ERR" } }`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`health_status{cluster="ceph"} 2`),
 				regexp.MustCompile(`health_status_interp{cluster="ceph"} 3`),


### PR DESCRIPTION
Switching the prometheus gauges to ConstMetrics will help address the issue of some metrics being at wrong values (eg. ceph_pg_state).

Addresses issue #102 

Not all gauges have been moved to ConstMetrics in health.go - the ones related to OSD mapping stayed as gauges. This is because existing logic and unit tests need them initialized at 0 and then updated based on certain flags, which is more difficult to do when using ConstMetrics.