### PR TITLE
Collector init fix and version refactor

### DIFF
--- a/ceph/cluster_usage.go
+++ b/ceph/cluster_usage.go
@@ -30,9 +30,8 @@ const (
 // is growing or shrinking as a whole in order to zero in on the cause. The
 // pool specific stats are provided separately.
 type ClusterUsageCollector struct {
-	conn    Conn
-	logger  *logrus.Logger
-	version *Version
+	conn   Conn
+	logger *logrus.Logger
 
 	// GlobalCapacity displays the total storage capacity of the cluster. This
 	// information is based on the actual no. of objects that are
@@ -55,9 +54,8 @@ func NewClusterUsageCollector(exporter *Exporter) *ClusterUsageCollector {
 	labels["cluster"] = exporter.Cluster
 
 	return &ClusterUsageCollector{
-		conn:    exporter.Conn,
-		logger:  exporter.Logger,
-		version: exporter.Version,
+		conn:   exporter.Conn,
+		logger: exporter.Logger,
 
 		GlobalCapacity: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace:   cephNamespace,
@@ -106,7 +104,6 @@ func (c *ClusterUsageCollector) collect() error {
 
 		return err
 	}
-
 	stats := &cephClusterStats{}
 	if err := json.Unmarshal(buf, stats); err != nil {
 		return err
@@ -143,7 +140,7 @@ func (c *ClusterUsageCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect sends the metric values for each metric pertaining to the global
 // cluster usage over to the provided prometheus Metric channel.
-func (c *ClusterUsageCollector) Collect(ch chan<- prometheus.Metric) {
+func (c *ClusterUsageCollector) Collect(ch chan<- prometheus.Metric, version *Version) {
 	c.logger.Debug("collecting cluster usage metrics")
 	if err := c.collect(); err != nil {
 		c.logger.WithError(err).Error("error collecting cluster usage metrics")

--- a/ceph/cluster_usage_test.go
+++ b/ceph/cluster_usage_test.go
@@ -15,14 +15,12 @@
 package ceph
 
 import (
-	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
@@ -137,32 +135,7 @@ func TestClusterUsage(t *testing.T) {
 		},
 	} {
 		func() {
-			conn := &MockConn{}
-			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
-				v := map[string]interface{}{}
-
-				err := json.Unmarshal(in.([]byte), &v)
-				require.NoError(t, err)
-
-				return cmp.Equal(v, map[string]interface{}{
-					"prefix": "version",
-					"format": "json",
-				})
-			})).Return([]byte(tt.version), "", nil)
-
-			// versions is only used to check if rbd mirror is present
-			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
-				v := map[string]interface{}{}
-
-				err := json.Unmarshal(in.([]byte), &v)
-				require.NoError(t, err)
-
-				return cmp.Equal(v, map[string]interface{}{
-					"prefix": "versions",
-					"format": "json",
-				})
-			})).Return([]byte(`{}`), "", nil)
-
+			conn := setupVersionMocks(tt.version, "{}")
 			conn.On("MonCommand", mock.Anything).Return(
 				[]byte(tt.input), "", nil,
 			)

--- a/ceph/crashes.go
+++ b/ceph/crashes.go
@@ -31,9 +31,8 @@ var (
 // This is NOT the same as new_crash_reports, that only counts new reports in the past
 // two weeks as reported by 'ceph health'.
 type CrashesCollector struct {
-	conn    Conn
-	logger  *logrus.Logger
-	version *Version
+	conn   Conn
+	logger *logrus.Logger
 
 	crashReportsDesc *prometheus.Desc
 }
@@ -44,9 +43,8 @@ func NewCrashesCollector(exporter *Exporter) *CrashesCollector {
 	labels["cluster"] = exporter.Cluster
 
 	collector := &CrashesCollector{
-		conn:    exporter.Conn,
-		logger:  exporter.Logger,
-		version: exporter.Version,
+		conn:   exporter.Conn,
+		logger: exporter.Logger,
 
 		crashReportsDesc: prometheus.NewDesc(
 			fmt.Sprintf("%s_crash_reports", cephNamespace),
@@ -106,7 +104,7 @@ func (c *CrashesCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 // Collect sends all the collected metrics Prometheus.
-func (c *CrashesCollector) Collect(ch chan<- prometheus.Metric) {
+func (c *CrashesCollector) Collect(ch chan<- prometheus.Metric, version *Version) {
 	crashes, err := c.getCrashLs()
 	if err != nil {
 		c.logger.WithError(err).Error("failed to run 'ceph crash ls'")

--- a/ceph/crashes_test.go
+++ b/ceph/crashes_test.go
@@ -15,14 +15,12 @@
 package ceph
 
 import (
-	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
@@ -191,32 +189,7 @@ func TestCrashesCollector(t *testing.T) {
 		t.Run(
 			tt.name,
 			func(t *testing.T) {
-				conn := &MockConn{}
-				conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
-					v := map[string]interface{}{}
-
-					err := json.Unmarshal(in.([]byte), &v)
-					require.NoError(t, err)
-
-					return cmp.Equal(v, map[string]interface{}{
-						"prefix": "version",
-						"format": "json",
-					})
-				})).Return([]byte(tt.version), "", nil)
-
-				// versions is only used to check if rbd mirror is present
-				conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
-					v := map[string]interface{}{}
-
-					err := json.Unmarshal(in.([]byte), &v)
-					require.NoError(t, err)
-
-					return cmp.Equal(v, map[string]interface{}{
-						"prefix": "versions",
-						"format": "json",
-					})
-				})).Return([]byte(`{}`), "", nil)
-
+				conn := setupVersionMocks(tt.version, "{}")
 				conn.On("MonCommand", mock.Anything).Return(
 					[]byte(tt.input), "", nil,
 				)

--- a/ceph/exporter.go
+++ b/ceph/exporter.go
@@ -39,12 +39,13 @@ type Exporter struct {
 	RbdMirror bool
 	Logger    *logrus.Logger
 	Version   *Version
+	cc        map[string]interface{}
 }
 
 // NewExporter returns an initialized *Exporter
 // We can choose to enable a collector to extract stats out of by adding it to the list of collectors.
 func NewExporter(conn Conn, cluster string, config string, user string, rgwMode int, logger *logrus.Logger) *Exporter {
-	return &Exporter{
+	e := &Exporter{
 		Conn:    conn,
 		Cluster: cluster,
 		Config:  config,
@@ -52,28 +53,32 @@ func NewExporter(conn Conn, cluster string, config string, user string, rgwMode 
 		RgwMode: rgwMode,
 		Logger:  logger,
 	}
+	err := e.setCephVersion()
+	if err != nil {
+		e.Logger.WithError(err).Error("failed to set ceph version")
+		return nil
+	}
+	e.cc = e.initCollectors()
+
+	return e
 }
 
-func (exporter *Exporter) getCollectors() []prometheus.Collector {
-	standardCollectors := []prometheus.Collector{
-		NewClusterUsageCollector(exporter),
-		NewPoolUsageCollector(exporter),
-		NewPoolInfoCollector(exporter),
-		NewClusterHealthCollector(exporter),
-		NewMonitorCollector(exporter),
-		NewOSDCollector(exporter),
-		NewCrashesCollector(exporter),
-	}
-
-	if exporter.RbdMirror {
-		standardCollectors = append(standardCollectors, NewRbdMirrorStatusCollector(exporter))
+func (exporter *Exporter) initCollectors() map[string]interface{} {
+	standardCollectors := map[string]interface{}{
+		"clusterUage":   NewClusterUsageCollector(exporter),
+		"poolUsage":     NewPoolUsageCollector(exporter),
+		"poolInfo":      NewPoolInfoCollector(exporter),
+		"clusterHealth": NewClusterHealthCollector(exporter),
+		"mon":           NewMonitorCollector(exporter),
+		"osd":           NewOSDCollector(exporter),
+		"crashes":       NewCrashesCollector(exporter),
 	}
 
 	switch exporter.RgwMode {
 	case RGWModeForeground:
-		standardCollectors = append(standardCollectors, NewRGWCollector(exporter, false))
+		standardCollectors["rgw"] = NewRGWCollector(exporter, false)
 	case RGWModeBackground:
-		standardCollectors = append(standardCollectors, NewRGWCollector(exporter, true))
+		standardCollectors["rgw"] = NewRGWCollector(exporter, true)
 	case RGWModeDisabled:
 		// nothing to do
 	default:
@@ -165,7 +170,14 @@ func (exporter *Exporter) setRbdMirror() error {
 	// check to see if rbd-mirror is in ceph version output and not empty
 	if _, exists := versions["rbd-mirror"]; exists {
 		if len(versions["rbd-mirror"]) > 0 {
-			exporter.RbdMirror = true
+			if _, ok := exporter.cc["rbdMirror"]; !ok {
+				exporter.cc["rbdMirror"] = NewRbdMirrorStatusCollector(exporter)
+			}
+		}
+	} else {
+		// remove the rbdMirror collector if present
+		if _, ok := exporter.cc["rbdMirror"]; ok {
+			delete(exporter.cc, "rbdMirror")
 		}
 	}
 
@@ -213,7 +225,7 @@ func (exporter *Exporter) Describe(ch chan<- *prometheus.Desc) {
 		return
 	}
 
-	for _, cc := range exporter.getCollectors() {
+	for _, cc := range exporter.cc {
 		cc.Describe(ch)
 	}
 }
@@ -237,7 +249,7 @@ func (exporter *Exporter) Collect(ch chan<- prometheus.Metric) {
 		return
 	}
 
-	for _, cc := range exporter.getCollectors() {
+	for _, cc := range exporter.cc {
 		cc.Collect(ch)
 	}
 }

--- a/ceph/exporter.go
+++ b/ceph/exporter.go
@@ -226,7 +226,26 @@ func (exporter *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	}
 
 	for _, cc := range exporter.cc {
-		cc.Describe(ch)
+		switch cc.(type) {
+		case *ClusterUsageCollector:
+			cc.(*ClusterUsageCollector).Describe(ch)
+		case *PoolUsageCollector:
+			cc.(*PoolUsageCollector).Describe(ch)
+		case *PoolInfoCollector:
+			cc.(*PoolInfoCollector).Describe(ch)
+		case *ClusterHealthCollector:
+			cc.(*ClusterHealthCollector).Describe(ch)
+		case *MonitorCollector:
+			cc.(*MonitorCollector).Describe(ch)
+		case *OSDCollector:
+			cc.(*OSDCollector).Describe(ch)
+		case *CrashesCollector:
+			cc.(*CrashesCollector).Describe(ch)
+		case *RbdMirrorStatusCollector:
+			cc.(*RbdMirrorStatusCollector).Describe(ch)
+		case *RGWCollector:
+			cc.(*RGWCollector).Describe(ch)
+		}
 	}
 }
 
@@ -250,6 +269,25 @@ func (exporter *Exporter) Collect(ch chan<- prometheus.Metric) {
 	}
 
 	for _, cc := range exporter.cc {
-		cc.Collect(ch)
+		switch cc.(type) {
+		case *ClusterUsageCollector:
+			cc.(*ClusterUsageCollector).Collect(ch, exporter.Version)
+		case *PoolUsageCollector:
+			cc.(*PoolUsageCollector).Collect(ch, exporter.Version)
+		case *PoolInfoCollector:
+			cc.(*PoolInfoCollector).Collect(ch, exporter.Version)
+		case *ClusterHealthCollector:
+			cc.(*ClusterHealthCollector).Collect(ch, exporter.Version)
+		case *MonitorCollector:
+			cc.(*MonitorCollector).Collect(ch, exporter.Version)
+		case *OSDCollector:
+			cc.(*OSDCollector).Collect(ch, exporter.Version)
+		case *CrashesCollector:
+			cc.(*CrashesCollector).Collect(ch, exporter.Version)
+		case *RbdMirrorStatusCollector:
+			cc.(*RbdMirrorStatusCollector).Collect(ch, exporter.Version)
+		case *RGWCollector:
+			cc.(*RGWCollector).Collect(ch, exporter.Version)
+		}
 	}
 }

--- a/ceph/health_test.go
+++ b/ceph/health_test.go
@@ -15,14 +15,12 @@
 package ceph
 
 import (
-	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
@@ -817,32 +815,7 @@ $ sudo ceph -s
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			conn := &MockConn{}
-			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
-				v := map[string]interface{}{}
-
-				err := json.Unmarshal(in.([]byte), &v)
-				require.NoError(t, err)
-
-				return cmp.Equal(v, map[string]interface{}{
-					"prefix": "version",
-					"format": "json",
-				})
-			})).Return([]byte(tt.version), "", nil)
-
-			// versions is only used to check if rbd mirror is present
-			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
-				v := map[string]interface{}{}
-
-				err := json.Unmarshal(in.([]byte), &v)
-				require.NoError(t, err)
-
-				return cmp.Equal(v, map[string]interface{}{
-					"prefix": "versions",
-					"format": "json",
-				})
-			})).Return([]byte(`{}`), "", nil)
-
+			conn := setupVersionMocks(tt.version, "{}")
 			conn.On("MonCommand", mock.Anything).Return(
 				[]byte(tt.input), "", nil,
 			)

--- a/ceph/health_test.go
+++ b/ceph/health_test.go
@@ -15,12 +15,14 @@
 package ceph
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
@@ -29,14 +31,11 @@ import (
 )
 
 func TestClusterHealthCollector(t *testing.T) {
-	allVersions := []*Version{Nautilus, Octopus, Pacific}
-	nautilusOnly := []*Version{Nautilus}
-	octopusPlus := []*Version{Octopus, Pacific}
 	for _, tt := range []struct {
-		name     string
-		versions []*Version // Defaults to allVersions if not provided.
-		input    string
-		reMatch  []*regexp.Regexp
+		name    string
+		version string
+		input   string
+		reMatch []*regexp.Regexp
 	}{
 		{
 			name: "15 pgs stuck degraded",
@@ -44,6 +43,7 @@ func TestClusterHealthCollector(t *testing.T) {
 {
 	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "15 pgs stuck degraded"}]}
 }`,
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`stuck_degraded_pgs{cluster="ceph"} 15`),
 			},
@@ -54,6 +54,7 @@ func TestClusterHealthCollector(t *testing.T) {
 {
 	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "16 pgs stuck unclean"}]}
 }`,
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`stuck_unclean_pgs{cluster="ceph"} 16`),
 			},
@@ -64,6 +65,7 @@ func TestClusterHealthCollector(t *testing.T) {
 {
 	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "17 pgs stuck undersized"}]}
 }`,
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`stuck_undersized_pgs{cluster="ceph"} 17`),
 			},
@@ -74,6 +76,7 @@ func TestClusterHealthCollector(t *testing.T) {
 {
 	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "18 pgs stuck stale"}]}
 }`,
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`stuck_stale_pgs{cluster="ceph"} 18`),
 			},
@@ -84,6 +87,7 @@ func TestClusterHealthCollector(t *testing.T) {
 {
 	"pgmap": { "degraded_objects": 10 }
 }`,
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`degraded_objects{cluster="ceph"} 10`),
 			},
@@ -94,13 +98,14 @@ func TestClusterHealthCollector(t *testing.T) {
 {
 	"pgmap": { "misplaced_objects": 20 }
 }`,
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`misplaced_objects{cluster="ceph"} 20`),
 			},
 		},
 		{
-			name:     "10 down osds",
-			versions: nautilusOnly,
+			name:    "10 down osds",
+			version: `{"version":"ceph version 14.2.9-12-zasd (1337) pacific (stable)"}`,
 			input: `
 {
 	"osdmap": {
@@ -117,8 +122,8 @@ func TestClusterHealthCollector(t *testing.T) {
 			},
 		},
 		{
-			name:     "normal osdmap",
-			versions: nautilusOnly,
+			name:    "normal osdmap",
+			version: `{"version":"ceph version 14.2.9-12-zasd (1337) pacific (stable)"}`,
 			input: `
 {
 	"osdmap": {
@@ -139,8 +144,8 @@ func TestClusterHealthCollector(t *testing.T) {
 			},
 		},
 		{
-			name:     "10 down osds",
-			versions: octopusPlus,
+			name:    "10 down osds",
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			input: `
 {
 	"osdmap": {
@@ -155,8 +160,8 @@ func TestClusterHealthCollector(t *testing.T) {
 			},
 		},
 		{
-			name:     "normal osdmap",
-			versions: octopusPlus,
+			name:    "normal osdmap",
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			input: `
 {
 	"osdmap": {
@@ -175,39 +180,44 @@ func TestClusterHealthCollector(t *testing.T) {
 			},
 		},
 		{
-			name:  "health ok",
-			input: `{"health": { "status": "HEALTH_OK" } }`,
+			name:    "health ok",
+			input:   `{"health": { "status": "HEALTH_OK" } }`,
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`health_status{cluster="ceph"} 0`),
 			},
 		},
 		{
-			name:  "health warn",
-			input: `{"health": { "status": "HEALTH_OK" } }`,
-			reMatch: []*regexp.Regexp{
-				regexp.MustCompile(`health_status{cluster="ceph"} 0`),
-				regexp.MustCompile(`health_status_interp{cluster="ceph"} 0`),
-			},
-		},
-		{
-			name:  "health ok 2",
-			input: `{"health": { "status": "HEALTH_OK" } }`,
+			name:    "health warn",
+			input:   `{"health": { "status": "HEALTH_OK" } }`,
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`health_status{cluster="ceph"} 0`),
 				regexp.MustCompile(`health_status_interp{cluster="ceph"} 0`),
 			},
 		},
 		{
-			name:  "health warn 2",
-			input: `{"health": { "status": "HEALTH_WARN" } }`,
+			name:    "health ok 2",
+			input:   `{"health": { "status": "HEALTH_OK" } }`,
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
+			reMatch: []*regexp.Regexp{
+				regexp.MustCompile(`health_status{cluster="ceph"} 0`),
+				regexp.MustCompile(`health_status_interp{cluster="ceph"} 0`),
+			},
+		},
+		{
+			name:    "health warn 2",
+			input:   `{"health": { "status": "HEALTH_WARN" } }`,
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`health_status{cluster="ceph"} 1`),
 				regexp.MustCompile(`health_status_interp{cluster="ceph"} 2`),
 			},
 		},
 		{
-			name:  "health err",
-			input: `{"health": { "status": "HEALTH_ERR" } }`,
+			name:    "health err",
+			input:   `{"health": { "status": "HEALTH_ERR" } }`,
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`health_status{cluster="ceph"} 2`),
 				regexp.MustCompile(`health_status_interp{cluster="ceph"} 3`),
@@ -223,6 +233,7 @@ $ sudo ceph -s
   recovery io 5779 MB/s, 4 keys/s, 1522 objects/s
   client io 4273 kB/s rd, 2740 MB/s wr, 2863 op/s
 `,
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`recovery_io_bytes{cluster="ceph"} 5.779e`),
 				regexp.MustCompile(`recovery_io_keys{cluster="ceph"} 4`),
@@ -243,6 +254,7 @@ $ sudo ceph -s
   client io 2863 op/s rd, 5847 op/s wr
   cache io 251 MB/s flush, 6646 kB/s evict, 55 op/s promote
 `,
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`recovery_io_bytes{cluster="ceph"} 5.779e`),
 				regexp.MustCompile(`recovery_io_keys{cluster="ceph"} 4`),
@@ -262,6 +274,7 @@ $ sudo ceph -s
 	"pgmap": { "num_pgs": 52000, "num_objects": 13156 },
 	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "7 pgs undersized"}]}
 }`,
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`total_pgs{cluster="ceph"} 52000`),
 				regexp.MustCompile(`cluster_objects{cluster="ceph"} 13156`),
@@ -303,6 +316,7 @@ $ sudo ceph -s
 	},
 	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "7 pgs undersized"}]}
 }`,
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`active_pgs{cluster="ceph"} 49`),
 				regexp.MustCompile(`scrubbing_pgs{cluster="ceph"} 2`),
@@ -329,6 +343,7 @@ $ sudo ceph -s
     }
   }
 }`,
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`mons_down{cluster="ceph"} 1`),
 			},
@@ -346,6 +361,7 @@ $ sudo ceph -s
 		]
 	}
 }`,
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`slow_requests{cluster="ceph"} 3`),
 			},
@@ -365,6 +381,7 @@ $ sudo ceph -s
     }
   }
 }`,
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`slow_requests{cluster="ceph"} 3`),
 			},
@@ -384,6 +401,7 @@ $ sudo ceph -s
     }
   }
 }`,
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`slow_requests{cluster="ceph"} 18`),
 			},
@@ -404,6 +422,7 @@ $ sudo ceph -s
   },
   "pgmap": { "degraded_objects": 154443937 }
 }`,
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`degraded_objects{cluster="ceph"} 1.54443937e\+08`),
 				regexp.MustCompile(`health_status_interp{cluster="ceph"} 1`),
@@ -424,6 +443,7 @@ $ sudo ceph -s
     }
   }
 }`,
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`new_crash_reports{cluster="ceph"} 2`),
 				regexp.MustCompile(`health_status_interp{cluster="ceph"} 1`),
@@ -444,6 +464,7 @@ $ sudo ceph -s
     }
   }
 }`,
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`osds_too_many_repair{cluster="ceph"} 25`),
 				regexp.MustCompile(`health_status_interp{cluster="ceph"} 1`),
@@ -464,6 +485,7 @@ $ sudo ceph -s
     }
   }
 }`,
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`health_status_interp{cluster="ceph"} 2`),
 			},
@@ -483,6 +505,7 @@ $ sudo ceph -s
     }
   }
 }`,
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`osdmap_flag_full{cluster="ceph"} 0`),
 				regexp.MustCompile(`osdmap_flag_pauserd{cluster="ceph"} 1`),
@@ -515,6 +538,7 @@ $ sudo ceph -s
 				}
 			  }
 			}`,
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`osd_map_flags{cluster="ceph",flag="pauserd"} 1`),
 				regexp.MustCompile(`osd_map_flags{cluster="ceph",flag="pausewr"} 1`),
@@ -628,6 +652,7 @@ $ sudo ceph -s
 		"bytes_total": 2537720565469184
 	}	
 }`,
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`active_pgs{cluster="ceph"} 44`),
 				regexp.MustCompile(`degraded_pgs{cluster="ceph"} 40`),
@@ -674,8 +699,8 @@ $ sudo ceph -s
 			},
 		},
 		{
-			name:     "manager map",
-			versions: nautilusOnly,
+			name:    "manager map",
+			version: `{"version":"ceph version 14.2.9-12-zasd (1337) pacific (stable)"}`,
 			input: `
 {
     "mgrmap": {
@@ -725,8 +750,8 @@ $ sudo ceph -s
 			},
 		},
 		{
-			name:     "manager map",
-			versions: octopusPlus,
+			name:    "manager map",
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			input: `
 {
     "mgrmap": {
@@ -784,6 +809,7 @@ $ sudo ceph -s
         }
     }
 }`,
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`rbd_mirror_up{cluster="ceph",\s*name="prod-mon01-block01"} 1`),
 				regexp.MustCompile(`rbd_mirror_up{cluster="ceph",\s*name="prod-mon02-block01"} 1`),
@@ -791,38 +817,58 @@ $ sudo ceph -s
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			versions := allVersions
-			if len(tt.versions) > 0 {
-				versions = tt.versions
-			}
-			for _, version := range versions {
-				t.Run(version.String(), func(t *testing.T) {
-					conn := &MockConn{}
-					conn.On("MonCommand", mock.Anything).Return(
-						[]byte(tt.input), "", nil,
-					)
+			conn := &MockConn{}
+			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
+				v := map[string]interface{}{}
 
-					collector := NewClusterHealthCollector(&Exporter{Conn: conn, Cluster: "ceph", Logger: logrus.New(), Version: version})
-					err := prometheus.Register(collector)
-					require.NoError(t, err)
-					defer prometheus.Unregister(collector)
+				err := json.Unmarshal(in.([]byte), &v)
+				require.NoError(t, err)
 
-					server := httptest.NewServer(promhttp.Handler())
-					defer server.Close()
-
-					resp, err := http.Get(server.URL)
-					require.NoError(t, err)
-					defer resp.Body.Close()
-
-					buf, err := ioutil.ReadAll(resp.Body)
-					require.NoError(t, err)
-
-					for _, re := range tt.reMatch {
-						if !re.Match(buf) {
-							t.Errorf("expected %s to match\n", re.String())
-						}
-					}
+				return cmp.Equal(v, map[string]interface{}{
+					"prefix": "version",
+					"format": "json",
 				})
+			})).Return([]byte(tt.version), "", nil)
+
+			// versions is only used to check if rbd mirror is present
+			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
+				v := map[string]interface{}{}
+
+				err := json.Unmarshal(in.([]byte), &v)
+				require.NoError(t, err)
+
+				return cmp.Equal(v, map[string]interface{}{
+					"prefix": "versions",
+					"format": "json",
+				})
+			})).Return([]byte(`{}`), "", nil)
+
+			conn.On("MonCommand", mock.Anything).Return(
+				[]byte(tt.input), "", nil,
+			)
+			e := &Exporter{Conn: conn, Cluster: "ceph", Logger: logrus.New()}
+			e.cc = map[string]interface{}{
+				"clusterHealth": NewClusterHealthCollector(e),
+			}
+
+			err := prometheus.Register(e)
+			require.NoError(t, err)
+			defer prometheus.Unregister(e)
+
+			server := httptest.NewServer(promhttp.Handler())
+			defer server.Close()
+
+			resp, err := http.Get(server.URL)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			buf, err := ioutil.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			for _, re := range tt.reMatch {
+				if !re.Match(buf) {
+					t.Errorf("expected %s to match\n", re.String())
+				}
 			}
 		})
 	}

--- a/ceph/monitors.go
+++ b/ceph/monitors.go
@@ -32,9 +32,8 @@ var versionRegexp = regexp.MustCompile(`ceph version (?P<version_tag>\d+\.\d+\.\
 // to each monitor instance, there are various vector metrics we
 // need to use.
 type MonitorCollector struct {
-	conn    Conn
-	logger  *logrus.Logger
-	version *Version
+	conn   Conn
+	logger *logrus.Logger
 
 	// TotalKBs display the total storage a given monitor node has.
 	TotalKBs *prometheus.GaugeVec
@@ -96,9 +95,8 @@ func NewMonitorCollector(exporter *Exporter) *MonitorCollector {
 	labels["cluster"] = exporter.Cluster
 
 	return &MonitorCollector{
-		conn:    exporter.Conn,
-		logger:  exporter.Logger,
-		version: exporter.Version,
+		conn:   exporter.Conn,
+		logger: exporter.Logger,
 
 		TotalKBs: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
@@ -553,7 +551,7 @@ func (m *MonitorCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect extracts the given metrics from the Monitors and sends it to the prometheus
 // channel.
-func (m *MonitorCollector) Collect(ch chan<- prometheus.Metric) {
+func (m *MonitorCollector) Collect(ch chan<- prometheus.Metric, version *Version) {
 	m.logger.Debug("collecting ceph monitor metrics")
 	if err := m.collect(); err != nil {
 		m.logger.WithError(err).Error("error collecting ceph monitor metrics")

--- a/ceph/monitors_test.go
+++ b/ceph/monitors_test.go
@@ -15,14 +15,12 @@
 package ceph
 
 import (
-	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
@@ -270,32 +268,7 @@ func TestMonitorCollector(t *testing.T) {
 		},
 	} {
 		func() {
-			conn := &MockConn{}
-			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
-				v := map[string]interface{}{}
-
-				err := json.Unmarshal(in.([]byte), &v)
-				require.NoError(t, err)
-
-				return cmp.Equal(v, map[string]interface{}{
-					"prefix": "version",
-					"format": "json",
-				})
-			})).Return([]byte(tt.version), "", nil)
-
-			// versions is only used to check if rbd mirror is present
-			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
-				v := map[string]interface{}{}
-
-				err := json.Unmarshal(in.([]byte), &v)
-				require.NoError(t, err)
-
-				return cmp.Equal(v, map[string]interface{}{
-					"prefix": "versions",
-					"format": "json",
-				})
-			})).Return([]byte(`{}`), "", nil)
-
+			conn := setupVersionMocks(tt.version, "{}")
 			conn.On("MonCommand", mock.Anything).Return(
 				[]byte(tt.input), "", nil,
 			)
@@ -426,32 +399,7 @@ func TestMonitorTimeSyncStats(t *testing.T) {
 		},
 	} {
 		func() {
-			conn := &MockConn{}
-			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
-				v := map[string]interface{}{}
-
-				err := json.Unmarshal(in.([]byte), &v)
-				require.NoError(t, err)
-
-				return cmp.Equal(v, map[string]interface{}{
-					"prefix": "version",
-					"format": "json",
-				})
-			})).Return([]byte(tt.version), "", nil)
-
-			// versions is only used to check if rbd mirror is present
-			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
-				v := map[string]interface{}{}
-
-				err := json.Unmarshal(in.([]byte), &v)
-				require.NoError(t, err)
-
-				return cmp.Equal(v, map[string]interface{}{
-					"prefix": "versions",
-					"format": "json",
-				})
-			})).Return([]byte(`{}`), "", nil)
-
+			conn := setupVersionMocks(tt.version, "{}")
 			conn.On("MonCommand", mock.Anything).Return(
 				[]byte(tt.input), "", nil,
 			)
@@ -518,19 +466,7 @@ func TestMonitorCephVersions(t *testing.T) {
 		},
 	} {
 		func() {
-			conn := &MockConn{}
-			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
-				v := map[string]interface{}{}
-
-				err := json.Unmarshal(in.([]byte), &v)
-				require.NoError(t, err)
-
-				return cmp.Equal(v, map[string]interface{}{
-					"prefix": "version",
-					"format": "json",
-				})
-			})).Return([]byte(tt.version), "", nil)
-
+			conn := setupVersionMocks(tt.version, tt.input)
 			conn.On("MonCommand", mock.Anything).Return(
 				[]byte(tt.input), "", nil,
 			)
@@ -616,32 +552,7 @@ func TestMonitorCephFeatures(t *testing.T) {
 		},
 	} {
 		func() {
-			conn := &MockConn{}
-			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
-				v := map[string]interface{}{}
-
-				err := json.Unmarshal(in.([]byte), &v)
-				require.NoError(t, err)
-
-				return cmp.Equal(v, map[string]interface{}{
-					"prefix": "version",
-					"format": "json",
-				})
-			})).Return([]byte(tt.version), "", nil)
-
-			// versions is only used to check if rbd mirror is present
-			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
-				v := map[string]interface{}{}
-
-				err := json.Unmarshal(in.([]byte), &v)
-				require.NoError(t, err)
-
-				return cmp.Equal(v, map[string]interface{}{
-					"prefix": "versions",
-					"format": "json",
-				})
-			})).Return([]byte(`{}`), "", nil)
-
+			conn := setupVersionMocks(tt.version, "{}")
 			conn.On("MonCommand", mock.Anything).Return(
 				[]byte(tt.input), "", nil,
 			)

--- a/ceph/monitors_test.go
+++ b/ceph/monitors_test.go
@@ -15,12 +15,14 @@
 package ceph
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
@@ -31,10 +33,11 @@ import (
 func TestMonitorCollector(t *testing.T) {
 	for _, tt := range []struct {
 		input   string
+		version string
 		regexes []*regexp.Regexp
 	}{
 		{
-			`
+			input: `
 {
     "health": {
         "health": {
@@ -210,7 +213,8 @@ func TestMonitorCollector(t *testing.T) {
     }
 }
 `,
-			[]*regexp.Regexp{
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
+			regexes: []*regexp.Regexp{
 				regexp.MustCompile(`ceph_monitor_avail_bytes{cluster="ceph",monitor="test-mon01"} 3.9927552e`),
 				regexp.MustCompile(`ceph_monitor_avail_bytes{cluster="ceph",monitor="test-mon02"} 3.99211569152e`),
 				regexp.MustCompile(`ceph_monitor_avail_bytes{cluster="ceph",monitor="test-mon03"} 3.98986235904e`),
@@ -267,14 +271,42 @@ func TestMonitorCollector(t *testing.T) {
 	} {
 		func() {
 			conn := &MockConn{}
+			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
+				v := map[string]interface{}{}
+
+				err := json.Unmarshal(in.([]byte), &v)
+				require.NoError(t, err)
+
+				return cmp.Equal(v, map[string]interface{}{
+					"prefix": "version",
+					"format": "json",
+				})
+			})).Return([]byte(tt.version), "", nil)
+
+			// versions is only used to check if rbd mirror is present
+			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
+				v := map[string]interface{}{}
+
+				err := json.Unmarshal(in.([]byte), &v)
+				require.NoError(t, err)
+
+				return cmp.Equal(v, map[string]interface{}{
+					"prefix": "versions",
+					"format": "json",
+				})
+			})).Return([]byte(`{}`), "", nil)
+
 			conn.On("MonCommand", mock.Anything).Return(
 				[]byte(tt.input), "", nil,
 			)
 
-			collector := NewMonitorCollector(&Exporter{Conn: conn, Cluster: "ceph", Logger: logrus.New()})
-			err := prometheus.Register(collector)
+			e := &Exporter{Conn: conn, Cluster: "ceph", Logger: logrus.New()}
+			e.cc = map[string]interface{}{
+				"mon": NewMonitorCollector(e),
+			}
+			err := prometheus.Register(e)
 			require.NoError(t, err)
-			defer prometheus.Unregister(collector)
+			defer prometheus.Unregister(e)
 
 			server := httptest.NewServer(promhttp.Handler())
 			defer server.Close()
@@ -296,9 +328,11 @@ func TestMonitorCollector(t *testing.T) {
 func TestMonitorTimeSyncStats(t *testing.T) {
 	for _, tt := range []struct {
 		input   string
+		version string
 		reMatch []*regexp.Regexp
 	}{
-		{`
+		{
+			input: `
             {
                 "time_skew_status": {
                     "test-mon01": {
@@ -334,7 +368,8 @@ func TestMonitorTimeSyncStats(t *testing.T) {
                 }
             }            
 `,
-			[]*regexp.Regexp{
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
+			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`ceph_monitor_clock_skew_seconds{cluster="ceph",monitor="test-mon01"} 2.2e\-05`),
 				regexp.MustCompile(`ceph_monitor_clock_skew_seconds{cluster="ceph",monitor="test-mon02"} 0.001051`),
 				regexp.MustCompile(`ceph_monitor_clock_skew_seconds{cluster="ceph",monitor="test-mon03"} 0.003029`),
@@ -347,7 +382,8 @@ func TestMonitorTimeSyncStats(t *testing.T) {
 				regexp.MustCompile(`ceph_monitor_latency_seconds{cluster="ceph",monitor="test-mon05"} 0.000667`),
 			},
 		},
-		{`
+		{
+			input: `
             {
                 "time_skew_status": {
                     "test-mon01": {
@@ -357,9 +393,11 @@ func TestMonitorTimeSyncStats(t *testing.T) {
                 }
             }            
 `,
-			[]*regexp.Regexp{},
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
+			reMatch: []*regexp.Regexp{},
 		},
-		{`
+		{
+			input: `
             {
                 "time_skew_status": {
                     "test-mon01": {
@@ -369,9 +407,11 @@ func TestMonitorTimeSyncStats(t *testing.T) {
                 }
             }            
 `,
-			[]*regexp.Regexp{},
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
+			reMatch: []*regexp.Regexp{},
 		},
-		{`
+		{
+			input: `
             {
                 "time_skew_status": {
                     "test-mon01": {
@@ -381,19 +421,48 @@ func TestMonitorTimeSyncStats(t *testing.T) {
                 }
             }            
 `,
-			[]*regexp.Regexp{},
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
+			reMatch: []*regexp.Regexp{},
 		},
 	} {
 		func() {
 			conn := &MockConn{}
+			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
+				v := map[string]interface{}{}
+
+				err := json.Unmarshal(in.([]byte), &v)
+				require.NoError(t, err)
+
+				return cmp.Equal(v, map[string]interface{}{
+					"prefix": "version",
+					"format": "json",
+				})
+			})).Return([]byte(tt.version), "", nil)
+
+			// versions is only used to check if rbd mirror is present
+			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
+				v := map[string]interface{}{}
+
+				err := json.Unmarshal(in.([]byte), &v)
+				require.NoError(t, err)
+
+				return cmp.Equal(v, map[string]interface{}{
+					"prefix": "versions",
+					"format": "json",
+				})
+			})).Return([]byte(`{}`), "", nil)
+
 			conn.On("MonCommand", mock.Anything).Return(
 				[]byte(tt.input), "", nil,
 			)
 
-			collector := NewMonitorCollector(&Exporter{Conn: conn, Cluster: "ceph", Logger: logrus.New()})
-			err := prometheus.Register(collector)
+			e := &Exporter{Conn: conn, Cluster: "ceph", Logger: logrus.New()}
+			e.cc = map[string]interface{}{
+				"mon": NewMonitorCollector(e),
+			}
+			err := prometheus.Register(e)
 			require.NoError(t, err)
-			defer prometheus.Unregister(collector)
+			defer prometheus.Unregister(e)
 
 			server := httptest.NewServer(promhttp.Handler())
 			defer server.Close()
@@ -415,9 +484,11 @@ func TestMonitorTimeSyncStats(t *testing.T) {
 func TestMonitorCephVersions(t *testing.T) {
 	for _, tt := range []struct {
 		input   string
+		version string
 		reMatch []*regexp.Regexp
 	}{
-		{`
+		{
+			input: `
 {
     "mon": {
         "ceph version 12.2.13 (584a20eb0237c657dc0567da126be145106aa47e) luminous (stable)": 5
@@ -439,7 +510,8 @@ func TestMonitorCephVersions(t *testing.T) {
     }
 }
 `,
-			[]*regexp.Regexp{
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
+			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`ceph_versions{cluster="ceph",daemon="mon",release_name="luminous",sha1="584a20eb0237c657dc0567da126be145106aa47e",version_tag="12.2.13"} 5`),
 				regexp.MustCompile(`ceph_versions{cluster="ceph",daemon="rgw",release_name="luminous",sha1="58a2283da6a62d2cc1600d4a9928a0799d63c7c9",version_tag="12.2.5-8-g58a2283"} 4`),
 			},
@@ -447,14 +519,29 @@ func TestMonitorCephVersions(t *testing.T) {
 	} {
 		func() {
 			conn := &MockConn{}
+			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
+				v := map[string]interface{}{}
+
+				err := json.Unmarshal(in.([]byte), &v)
+				require.NoError(t, err)
+
+				return cmp.Equal(v, map[string]interface{}{
+					"prefix": "version",
+					"format": "json",
+				})
+			})).Return([]byte(tt.version), "", nil)
+
 			conn.On("MonCommand", mock.Anything).Return(
 				[]byte(tt.input), "", nil,
 			)
 
-			collector := NewMonitorCollector(&Exporter{Conn: conn, Cluster: "ceph", Logger: logrus.New()})
-			err := prometheus.Register(collector)
+			e := &Exporter{Conn: conn, Cluster: "ceph", Logger: logrus.New()}
+			e.cc = map[string]interface{}{
+				"mon": NewMonitorCollector(e),
+			}
+			err := prometheus.Register(e)
 			require.NoError(t, err)
-			defer prometheus.Unregister(collector)
+			defer prometheus.Unregister(e)
 
 			server := httptest.NewServer(promhttp.Handler())
 			defer server.Close()
@@ -476,9 +563,11 @@ func TestMonitorCephVersions(t *testing.T) {
 func TestMonitorCephFeatures(t *testing.T) {
 	for _, tt := range []struct {
 		input   string
+		version string
 		reMatch []*regexp.Regexp
 	}{
-		{`
+		{
+			input: `
 {
     "mon": [
         {
@@ -520,21 +609,50 @@ func TestMonitorCephFeatures(t *testing.T) {
     ]
 }
 		`,
-			[]*regexp.Regexp{
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
+			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`ceph_features{cluster="ceph",daemon="client",features="0x3ffddff8ffacffff",release="luminous"} 53`),
 			},
 		},
 	} {
 		func() {
 			conn := &MockConn{}
+			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
+				v := map[string]interface{}{}
+
+				err := json.Unmarshal(in.([]byte), &v)
+				require.NoError(t, err)
+
+				return cmp.Equal(v, map[string]interface{}{
+					"prefix": "version",
+					"format": "json",
+				})
+			})).Return([]byte(tt.version), "", nil)
+
+			// versions is only used to check if rbd mirror is present
+			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
+				v := map[string]interface{}{}
+
+				err := json.Unmarshal(in.([]byte), &v)
+				require.NoError(t, err)
+
+				return cmp.Equal(v, map[string]interface{}{
+					"prefix": "versions",
+					"format": "json",
+				})
+			})).Return([]byte(`{}`), "", nil)
+
 			conn.On("MonCommand", mock.Anything).Return(
 				[]byte(tt.input), "", nil,
 			)
 
-			collector := NewMonitorCollector(&Exporter{Conn: conn, Cluster: "ceph", Logger: logrus.New()})
-			err := prometheus.Register(collector)
+			e := &Exporter{Conn: conn, Cluster: "ceph", Logger: logrus.New()}
+			e.cc = map[string]interface{}{
+				"mon": NewMonitorCollector(e),
+			}
+			err := prometheus.Register(e)
 			require.NoError(t, err)
-			defer prometheus.Unregister(collector)
+			defer prometheus.Unregister(e)
 
 			server := httptest.NewServer(promhttp.Handler())
 			defer server.Close()

--- a/ceph/osd.go
+++ b/ceph/osd.go
@@ -40,9 +40,8 @@ const (
 // An important aspect of monitoring OSDs is to ensure that when the cluster is
 // up and running that all OSDs that are in the cluster are up and running, too
 type OSDCollector struct {
-	conn    Conn
-	logger  *logrus.Logger
-	version *Version
+	conn   Conn
+	logger *logrus.Logger
 
 	// osdScrubCache holds the cache of previous PG scrubs
 	osdScrubCache map[int]int
@@ -152,9 +151,6 @@ type OSDCollector struct {
 	OldestInactivePG prometheus.Gauge
 }
 
-// This ensures OSDCollector implements interface prometheus.Collector.
-var _ prometheus.Collector = &OSDCollector{}
-
 // NewOSDCollector creates an instance of the OSDCollector and instantiates the
 // individual metrics that show information about the OSD.
 func NewOSDCollector(exporter *Exporter) *OSDCollector {
@@ -163,9 +159,8 @@ func NewOSDCollector(exporter *Exporter) *OSDCollector {
 	osdLabels := []string{"osd", "device_class", "host", "rack", "root"}
 
 	return &OSDCollector{
-		conn:    exporter.Conn,
-		logger:  exporter.Logger,
-		version: exporter.Version,
+		conn:   exporter.Conn,
+		logger: exporter.Logger,
 
 		osdScrubCache:       make(map[int]int),
 		osdLabelsCache:      make(map[int64]*cephOSDLabel),
@@ -1119,7 +1114,7 @@ func (o *OSDCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect sends all the collected metrics to the provided Prometheus channel.
 // It requires the caller to handle synchronization.
-func (o *OSDCollector) Collect(ch chan<- prometheus.Metric) {
+func (o *OSDCollector) Collect(ch chan<- prometheus.Metric, version *Version) {
 	// Reset daemon specifc metrics; daemons can leave the cluster
 	o.CrushWeight.Reset()
 	o.Depth.Reset()

--- a/ceph/osd_test.go
+++ b/ceph/osd_test.go
@@ -447,28 +447,33 @@ func TestOSDCollector(t *testing.T) {
 
 	for _, tt := range []struct {
 		test    string
+		version string
 		reMatch []*regexp.Regexp
 	}{
 		{
-			test: "1",
+			test:    "1",
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`ceph_osd_down{cluster="ceph",device_class="ssd",host="prod-data02-block01",osd="osd.524",rack="default",root="A8R2",status="destroyed"} 1`),
 			},
 		},
 		{
-			test: "2",
+			test:    "2",
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`ceph_osd_down{cluster="ceph",device_class="ssd",host="prod-data02-block01",osd="osd.524",rack="default",root="A8R2",status="down"} 1`),
 			},
 		},
 		{
-			test: "3",
+			test:    "3",
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`ceph_osd_down{cluster="ceph",device_class="ssd",host="prod-data02-block01",osd="osd.524",rack="default",root="A8R2",status="destroyed"} 1`),
 			},
 		},
 		{
-			test: "4",
+			test:    "4",
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`ceph_osd_down{cluster="ceph",device_class="ssd",host="prod-data02-block01",osd="osd.524",rack="default",root="A8R2",status="destroyed"} 1`),
 				regexp.MustCompile(`ceph_osd_down{cluster="ceph",device_class="ssd",host="prod-data02-block01",osd="osd.525",rack="default",root="A8R2",status="down"} 1`),
@@ -476,6 +481,7 @@ func TestOSDCollector(t *testing.T) {
 		},
 		{
 			test:    "5",
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			reMatch: []*regexp.Regexp{},
 		},
 	} {
@@ -965,11 +971,38 @@ func TestOSDCollector(t *testing.T) {
         ]
     }
 }`), "", nil)
+			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
+				v := map[string]interface{}{}
 
-			collector := NewOSDCollector(&Exporter{Conn: conn, Cluster: "ceph", Logger: logrus.New()})
-			err := prometheus.Register(collector)
+				err := json.Unmarshal(in.([]byte), &v)
+				require.NoError(t, err)
+
+				return cmp.Equal(v, map[string]interface{}{
+					"prefix": "version",
+					"format": "json",
+				})
+			})).Return([]byte(tt.version), "", nil)
+
+			// versions is only used to check if rbd mirror is present
+			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
+				v := map[string]interface{}{}
+
+				err := json.Unmarshal(in.([]byte), &v)
+				require.NoError(t, err)
+
+				return cmp.Equal(v, map[string]interface{}{
+					"prefix": "versions",
+					"format": "json",
+				})
+			})).Return([]byte(`{}`), "", nil)
+
+			e := &Exporter{Conn: conn, Cluster: "ceph", Logger: logrus.New()}
+			e.cc = map[string]interface{}{
+				"osd": NewOSDCollector(e),
+			}
+			err := prometheus.Register(e)
 			require.NoError(t, err)
-			defer prometheus.Unregister(collector)
+			defer prometheus.Unregister(e)
 
 			server := httptest.NewServer(promhttp.Handler())
 			defer server.Close()

--- a/ceph/osd_test.go
+++ b/ceph/osd_test.go
@@ -486,7 +486,7 @@ func TestOSDCollector(t *testing.T) {
 		},
 	} {
 		func() {
-			conn := &MockConn{}
+			conn := setupVersionMocks(tt.version, "{}")
 
 			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
 				v := map[string]interface{}{}
@@ -971,30 +971,6 @@ func TestOSDCollector(t *testing.T) {
         ]
     }
 }`), "", nil)
-			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
-				v := map[string]interface{}{}
-
-				err := json.Unmarshal(in.([]byte), &v)
-				require.NoError(t, err)
-
-				return cmp.Equal(v, map[string]interface{}{
-					"prefix": "version",
-					"format": "json",
-				})
-			})).Return([]byte(tt.version), "", nil)
-
-			// versions is only used to check if rbd mirror is present
-			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
-				v := map[string]interface{}{}
-
-				err := json.Unmarshal(in.([]byte), &v)
-				require.NoError(t, err)
-
-				return cmp.Equal(v, map[string]interface{}{
-					"prefix": "versions",
-					"format": "json",
-				})
-			})).Return([]byte(`{}`), "", nil)
 
 			e := &Exporter{Conn: conn, Cluster: "ceph", Logger: logrus.New()}
 			e.cc = map[string]interface{}{

--- a/ceph/pool.go
+++ b/ceph/pool.go
@@ -32,9 +32,8 @@ const (
 // PoolInfoCollector gives information about each pool that exists in a given
 // ceph cluster.
 type PoolInfoCollector struct {
-	conn    Conn
-	logger  *logrus.Logger
-	version *Version
+	conn   Conn
+	logger *logrus.Logger
 
 	// PGNum contains the count of PGs allotted to a particular pool.
 	PGNum *prometheus.GaugeVec
@@ -75,9 +74,8 @@ func NewPoolInfoCollector(exporter *Exporter) *PoolInfoCollector {
 	labels["cluster"] = exporter.Cluster
 
 	return &PoolInfoCollector{
-		conn:    exporter.Conn,
-		logger:  exporter.Logger,
-		version: exporter.Version,
+		conn:   exporter.Conn,
+		logger: exporter.Logger,
 
 		PGNum: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
@@ -261,7 +259,7 @@ func (p *PoolInfoCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect extracts the current values of all the metrics and sends them to the
 // prometheus channel.
-func (p *PoolInfoCollector) Collect(ch chan<- prometheus.Metric) {
+func (p *PoolInfoCollector) Collect(ch chan<- prometheus.Metric, version *Version) {
 	p.logger.Debug("collecting pool metrics")
 	if err := p.collect(); err != nil {
 		p.logger.WithError(err).Error("error collecting pool metrics")

--- a/ceph/pool_test.go
+++ b/ceph/pool_test.go
@@ -61,33 +61,7 @@ func TestPoolInfoCollector(t *testing.T) {
 		},
 	} {
 		func() {
-			conn := &MockConn{}
-
-			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
-				v := map[string]interface{}{}
-
-				err := json.Unmarshal(in.([]byte), &v)
-				require.NoError(t, err)
-
-				return cmp.Equal(v, map[string]interface{}{
-					"prefix": "version",
-					"format": "json",
-				})
-			})).Return([]byte(tt.version), "", nil)
-
-			// versions is only used to check if rbd mirror is present
-			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
-				v := map[string]interface{}{}
-
-				err := json.Unmarshal(in.([]byte), &v)
-				require.NoError(t, err)
-
-				return cmp.Equal(v, map[string]interface{}{
-					"prefix": "versions",
-					"format": "json",
-				})
-			})).Return([]byte(`{}`), "", nil)
-
+			conn := setupVersionMocks(tt.version, "{}")
 			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
 				v := map[string]interface{}{}
 

--- a/ceph/pool_test.go
+++ b/ceph/pool_test.go
@@ -33,9 +33,11 @@ import (
 
 func TestPoolInfoCollector(t *testing.T) {
 	for _, tt := range []struct {
+		version            string
 		reMatch, reUnmatch []*regexp.Regexp
 	}{
 		{
+			version: `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`pool_size{cluster="ceph",pool="rbd",profile="ec-4-2",root="non-default-root"} 6`),
 				regexp.MustCompile(`pool_min_size{cluster="ceph",pool="rbd",profile="ec-4-2",root="non-default-root"} 4`),
@@ -60,6 +62,32 @@ func TestPoolInfoCollector(t *testing.T) {
 	} {
 		func() {
 			conn := &MockConn{}
+
+			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
+				v := map[string]interface{}{}
+
+				err := json.Unmarshal(in.([]byte), &v)
+				require.NoError(t, err)
+
+				return cmp.Equal(v, map[string]interface{}{
+					"prefix": "version",
+					"format": "json",
+				})
+			})).Return([]byte(tt.version), "", nil)
+
+			// versions is only used to check if rbd mirror is present
+			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
+				v := map[string]interface{}{}
+
+				err := json.Unmarshal(in.([]byte), &v)
+				require.NoError(t, err)
+
+				return cmp.Equal(v, map[string]interface{}{
+					"prefix": "versions",
+					"format": "json",
+				})
+			})).Return([]byte(`{}`), "", nil)
+
 			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
 				v := map[string]interface{}{}
 
@@ -181,11 +209,13 @@ func TestPoolInfoCollector(t *testing.T) {
 				})
 			})).Return([]byte(""), "", fmt.Errorf("unknown erasure code profile"))
 
-			collector := NewPoolInfoCollector(&Exporter{Conn: conn, Cluster: "ceph", Logger: logrus.New()})
-
-			err := prometheus.Register(collector)
+			e := &Exporter{Conn: conn, Cluster: "ceph", Logger: logrus.New()}
+			e.cc = map[string]interface{}{
+				"poolInfo": NewPoolInfoCollector(e),
+			}
+			err := prometheus.Register(e)
 			require.NoError(t, err)
-			defer prometheus.Unregister(collector)
+			defer prometheus.Unregister(e)
 
 			server := httptest.NewServer(promhttp.Handler())
 			defer server.Close()

--- a/ceph/pool_usage.go
+++ b/ceph/pool_usage.go
@@ -25,9 +25,8 @@ import (
 
 // PoolUsageCollector displays statistics about each pool in the Ceph cluster.
 type PoolUsageCollector struct {
-	conn    Conn
-	logger  *logrus.Logger
-	version *Version
+	conn   Conn
+	logger *logrus.Logger
 
 	// UsedBytes tracks the amount of bytes currently allocated for the pool. This
 	// does not factor in the overcommitment made for individual images.
@@ -80,9 +79,8 @@ func NewPoolUsageCollector(exporter *Exporter) *PoolUsageCollector {
 	labels["cluster"] = exporter.Cluster
 
 	return &PoolUsageCollector{
-		conn:    exporter.Conn,
-		logger:  exporter.Logger,
-		version: exporter.Version,
+		conn:   exporter.Conn,
+		logger: exporter.Logger,
 
 		UsedBytes: prometheus.NewDesc(fmt.Sprintf("%s_%s_used_bytes", cephNamespace, subSystem), "Capacity of the pool that is currently under use",
 			poolLabel, labels,
@@ -213,7 +211,7 @@ func (p *PoolUsageCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect extracts the current values of all the metrics and sends them to the
 // prometheus channel.
-func (p *PoolUsageCollector) Collect(ch chan<- prometheus.Metric) {
+func (p *PoolUsageCollector) Collect(ch chan<- prometheus.Metric, version *Version) {
 	p.logger.Debug("collecting pool usage metrics")
 	if err := p.collect(ch); err != nil {
 		p.logger.WithError(err).Error("error collecting pool usage metrics")

--- a/ceph/pool_usage_test.go
+++ b/ceph/pool_usage_test.go
@@ -15,7 +15,6 @@
 package ceph
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -23,7 +22,6 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
@@ -190,32 +188,7 @@ func TestPoolUsageCollector(t *testing.T) {
 		},
 	} {
 		func() {
-			conn := &MockConn{}
-
-			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
-				v := map[string]interface{}{}
-
-				err := json.Unmarshal(in.([]byte), &v)
-				require.NoError(t, err)
-
-				return cmp.Equal(v, map[string]interface{}{
-					"prefix": "version",
-					"format": "json",
-				})
-			})).Return([]byte(tt.version), "", nil)
-
-			// versions is only used to check if rbd mirror is present
-			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
-				v := map[string]interface{}{}
-
-				err := json.Unmarshal(in.([]byte), &v)
-				require.NoError(t, err)
-
-				return cmp.Equal(v, map[string]interface{}{
-					"prefix": "versions",
-					"format": "json",
-				})
-			})).Return([]byte(`{}`), "", nil)
+			conn := setupVersionMocks(tt.version, "{}")
 
 			conn.On("MonCommand", mock.Anything).Return(
 				[]byte(tt.input), "", nil,

--- a/ceph/rbd_mirror_status.go
+++ b/ceph/rbd_mirror_status.go
@@ -155,7 +155,7 @@ func (c *RbdMirrorStatusCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 // Collect sends all the collected metrics Prometheus.
-func (c *RbdMirrorStatusCollector) Collect(ch chan<- prometheus.Metric) {
+func (c *RbdMirrorStatusCollector) Collect(ch chan<- prometheus.Metric, version *Version) {
 	status, err := rbdMirrorStatus(c.config, c.user)
 	if err != nil {
 		c.logger.WithError(err).Error("failed to run 'rbd mirror pool status'")
@@ -166,6 +166,7 @@ func (c *RbdMirrorStatusCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 
 	c.RbdMirrorStatus.Set(c.mirrorStatusStringToInt(rbdStatus.Summary.Health))
+	c.version = version
 
 	if c.version.IsAtLeast(Pacific) {
 		c.RbdMirrorDaemonStatus.Set(c.mirrorStatusStringToInt(rbdStatus.Summary.DaemonHealth))

--- a/ceph/rbd_mirror_status_test.go
+++ b/ceph/rbd_mirror_status_test.go
@@ -22,9 +22,11 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -37,8 +39,10 @@ func setStatus(b []byte) {
 func TestRbdMirrorStatusCollector(t *testing.T) {
 
 	for _, tt := range []struct {
-		input   []byte
-		reMatch []*regexp.Regexp
+		input    []byte
+		version  string
+		versions string
+		reMatch  []*regexp.Regexp
 	}{
 		{
 			input: []byte(`
@@ -52,6 +56,8 @@ func TestRbdMirrorStatusCollector(t *testing.T) {
 				  }
 				}
 			  }`),
+			version:  `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
+			versions: `{"rbd-mirror":{"ceph version 16.2.11-98-g1984a8c (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)":3}}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`ceph_rbd_mirror_pool_status{cluster="ceph"} 1`),
 				regexp.MustCompile(`ceph_rbd_mirror_pool_image_status{cluster="ceph"} 1`),
@@ -68,6 +74,8 @@ func TestRbdMirrorStatusCollector(t *testing.T) {
 				  "states": {}
 				}
 			  }`),
+			version:  `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
+			versions: `{"rbd-mirror":{"ceph version 16.2.11-98-g1984a8c (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)":3}}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`ceph_rbd_mirror_pool_status{cluster="ceph"} 1`),
 				regexp.MustCompile(`ceph_rbd_mirror_pool_daemon_status{cluster="ceph"} 1`),
@@ -84,6 +92,8 @@ func TestRbdMirrorStatusCollector(t *testing.T) {
 				  "states": {}
 				}
 			  }`),
+			version:  `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
+			versions: `{"rbd-mirror":{"ceph version 16.2.11-98-g1984a8c (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)":3}}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`ceph_rbd_mirror_pool_status{cluster="ceph"} 0`),
 				regexp.MustCompile(`ceph_rbd_mirror_pool_daemon_status{cluster="ceph"} 0`),
@@ -100,23 +110,68 @@ func TestRbdMirrorStatusCollector(t *testing.T) {
 				  "states": {}
 				}
 			  }`),
+			version:  `{"version":"ceph version 16.2.11-22-wasd (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)"}`,
+			versions: `{"rbd-mirror":{"ceph version 16.2.11-98-g1984a8c (1984a8c33225d70559cdf27dbab81e3ce153f6ac) pacific (stable)":3}}`,
 			reMatch: []*regexp.Regexp{
 				regexp.MustCompile(`ceph_rbd_mirror_pool_status{cluster="ceph"} 2`),
 				regexp.MustCompile(`ceph_rbd_mirror_pool_daemon_status{cluster="ceph"} 0`),
 				regexp.MustCompile(`ceph_rbd_mirror_pool_image_status{cluster="ceph"} 2`),
 			},
 		},
+		{
+			input: []byte(`
+			{
+				"summary": {
+				  "health": "OK",
+				  "daemon_health": "OK",
+				  "image_health": "ERROR"
+				}
+			  }`),
+			version:  `{"version":"ceph version 14.2.9-12-zasd (1337) pacific (stable)"}`,
+			versions: `{"rbd-mirror":{"ceph version 14.2.9-12-zasd (1337) pacific (stable)":3}}`,
+			reMatch: []*regexp.Regexp{
+				regexp.MustCompile(`ceph_rbd_mirror_pool_status{cluster="ceph"} 0`),
+			},
+		},
 	} {
 		func() {
-			collector := NewRbdMirrorStatusCollector(&Exporter{Cluster: "ceph", Version: Pacific, Logger: logrus.New()})
+			conn := &MockConn{}
+			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
+				v := map[string]interface{}{}
 
-			var rbdStatus rbdMirrorPoolStatus
-			setStatus(tt.input)
-			_ = json.Unmarshal([]byte(tt.input), &rbdStatus)
+				err := json.Unmarshal(in.([]byte), &v)
+				require.NoError(t, err)
 
-			err := prometheus.Register(collector)
+				return cmp.Equal(v, map[string]interface{}{
+					"prefix": "version",
+					"format": "json",
+				})
+			})).Return([]byte(tt.version), "", nil)
+
+			// versions is only used to check if rbd mirror is present
+			conn.On("MonCommand", mock.MatchedBy(func(in interface{}) bool {
+				v := map[string]interface{}{}
+
+				err := json.Unmarshal(in.([]byte), &v)
+				require.NoError(t, err)
+
+				return cmp.Equal(v, map[string]interface{}{
+					"prefix": "versions",
+					"format": "json",
+				})
+			})).Return([]byte(tt.versions), "", nil)
+
+			e := &Exporter{Conn: conn, Cluster: "ceph", Logger: logrus.New()}
+			// We do not create the rbdCollector since it will
+			// be automatically initiated from the output of `ceph versions`
+			// if the rbd-mirror key is present
+			e.cc = map[string]interface{}{}
+
+			err := prometheus.Register(e)
 			require.NoError(t, err)
-			defer prometheus.Unregister(collector)
+			defer prometheus.Unregister(e)
+
+			setStatus(tt.input)
 
 			server := httptest.NewServer(promhttp.Handler())
 			defer server.Close()

--- a/ceph/rgw.go
+++ b/ceph/rgw.go
@@ -76,7 +76,6 @@ type RGWCollector struct {
 	user       string
 	background bool
 	logger     *logrus.Logger
-	version    *Version
 
 	// ActiveTasks reports the number of (expired) RGW GC tasks
 	ActiveTasks *prometheus.GaugeVec
@@ -101,7 +100,6 @@ func NewRGWCollector(exporter *Exporter, background bool) *RGWCollector {
 		config:           exporter.Config,
 		background:       background,
 		logger:           exporter.Logger,
-		version:          exporter.Version,
 		getRGWGCTaskList: rgwGetGCTaskList,
 
 		ActiveTasks: prometheus.NewGaugeVec(
@@ -219,7 +217,7 @@ func (r *RGWCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect sends all the collected metrics to the provided prometheus channel.
 // It requires the caller to handle synchronization.
-func (r *RGWCollector) Collect(ch chan<- prometheus.Metric) {
+func (r *RGWCollector) Collect(ch chan<- prometheus.Metric, version *Version) {
 	if !r.background {
 		r.logger.WithField("background", r.background).Debug("collecting RGW GC stats")
 		err := r.collect()


### PR DESCRIPTION
The previous code caused all the collector to get re-initialized when we called Collect() breaking metrics relying on stored state such as `ceph_pg_oldest_inactive`. 
We now store the collectors in a map. By itself, this broke some features that were inherited from constant re-init:
 - ability to collect metrics post upgrade without restart if command output change
 - dynamically loading the rbd mirror collector

In order to not have to restart ceph exporter on upgrades we now pass the ceph version when we call `Collect()` on collector. This triggered a lot of changes including all the tests.
For the rbd mirror collection the feature is kept by storing the collectors in map.