### PR TITLE
Fix timeouts and use goroutines for collectors/commands

### DIFF
--- a/ceph/cluster_usage.go
+++ b/ceph/cluster_usage.go
@@ -16,6 +16,7 @@ package ceph
 
 import (
 	"encoding/json"
+	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
@@ -140,7 +141,9 @@ func (c *ClusterUsageCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect sends the metric values for each metric pertaining to the global
 // cluster usage over to the provided prometheus Metric channel.
-func (c *ClusterUsageCollector) Collect(ch chan<- prometheus.Metric, version *Version) {
+func (c *ClusterUsageCollector) Collect(ch chan<- prometheus.Metric, version *Version, wg *sync.WaitGroup) {
+	defer wg.Done()
+
 	c.logger.Debug("collecting cluster usage metrics")
 	if err := c.collect(); err != nil {
 		c.logger.WithError(err).Error("error collecting cluster usage metrics")

--- a/ceph/crashes.go
+++ b/ceph/crashes.go
@@ -17,6 +17,7 @@ package ceph
 import (
 	"encoding/json"
 	"fmt"
+	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
@@ -104,7 +105,9 @@ func (c *CrashesCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 // Collect sends all the collected metrics Prometheus.
-func (c *CrashesCollector) Collect(ch chan<- prometheus.Metric, version *Version) {
+func (c *CrashesCollector) Collect(ch chan<- prometheus.Metric, version *Version, wg *sync.WaitGroup) {
+	defer wg.Done()
+
 	crashes, err := c.getCrashLs()
 	if err != nil {
 		c.logger.WithError(err).Error("failed to run 'ceph crash ls'")

--- a/ceph/exporter.go
+++ b/ceph/exporter.go
@@ -25,7 +25,7 @@ import (
 )
 
 type versionedCollector interface {
-	Collect(chan<- prometheus.Metric, *Version)
+	Collect(chan<- prometheus.Metric, *Version, *sync.WaitGroup)
 	Describe(chan<- *prometheus.Desc)
 }
 
@@ -254,7 +254,10 @@ func (exporter *Exporter) Collect(ch chan<- prometheus.Metric) {
 		return
 	}
 
+	wg := &sync.WaitGroup{}
 	for _, cc := range exporter.cc {
-		cc.Collect(ch, exporter.Version)
+		wg.Add(1)
+		go cc.Collect(ch, exporter.Version, wg)
 	}
+	wg.Wait()
 }

--- a/ceph/health.go
+++ b/ceph/health.go
@@ -1337,8 +1337,8 @@ func (c *ClusterHealthCollector) Describe(ch chan<- *prometheus.Desc) {
 func (c *ClusterHealthCollector) Collect(ch chan<- prometheus.Metric, version *Version, wg *sync.WaitGroup) {
 	defer wg.Done()
 	localWg := &sync.WaitGroup{}
-	localWg.Add(2)
 
+	localWg.Add(1)
 	go func() {
 		defer localWg.Done()
 
@@ -1348,6 +1348,7 @@ func (c *ClusterHealthCollector) Collect(ch chan<- prometheus.Metric, version *V
 		}
 	}()
 
+	localWg.Add(1)
 	go func() {
 		defer localWg.Done()
 

--- a/ceph/monitors.go
+++ b/ceph/monitors.go
@@ -293,10 +293,10 @@ type cephFeatureGroup struct {
 
 func (m *MonitorCollector) collect() error {
 	wg := &sync.WaitGroup{}
-	wg.Add(4)
 
 	stats := &cephMonitorStats{}
 	var statsErr error
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		// Ceph usage
@@ -318,6 +318,7 @@ func (m *MonitorCollector) collect() error {
 
 	timeStats := &cephTimeSyncStatus{}
 	var timeErr error
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		// Ceph time sync status
@@ -339,6 +340,7 @@ func (m *MonitorCollector) collect() error {
 
 	var versionsErr error
 	var versions map[string]map[string]float64
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 
@@ -362,6 +364,7 @@ func (m *MonitorCollector) collect() error {
 
 	var featuresErr error
 	var buf []byte
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 

--- a/ceph/pool.go
+++ b/ceph/pool.go
@@ -197,8 +197,8 @@ func (p *PoolInfoCollector) collect() error {
 	var err error
 	var ruleToRootMappings map[int64]string
 	wg := &sync.WaitGroup{}
-	wg.Add(2)
 
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 
@@ -211,6 +211,7 @@ func (p *PoolInfoCollector) collect() error {
 		}
 	}()
 
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		ruleToRootMappings = p.getCrushRuleToRootMappings()

--- a/ceph/pool_usage.go
+++ b/ceph/pool_usage.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
@@ -211,7 +212,9 @@ func (p *PoolUsageCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect extracts the current values of all the metrics and sends them to the
 // prometheus channel.
-func (p *PoolUsageCollector) Collect(ch chan<- prometheus.Metric, version *Version) {
+func (p *PoolUsageCollector) Collect(ch chan<- prometheus.Metric, version *Version, wg *sync.WaitGroup) {
+	defer wg.Done()
+
 	p.logger.Debug("collecting pool usage metrics")
 	if err := p.collect(ch); err != nil {
 		p.logger.WithError(err).Error("error collecting pool usage metrics")

--- a/ceph/rbd_mirror_status.go
+++ b/ceph/rbd_mirror_status.go
@@ -17,6 +17,7 @@ package ceph
 import (
 	"encoding/json"
 	"os/exec"
+	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
@@ -155,7 +156,9 @@ func (c *RbdMirrorStatusCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 // Collect sends all the collected metrics Prometheus.
-func (c *RbdMirrorStatusCollector) Collect(ch chan<- prometheus.Metric, version *Version) {
+func (c *RbdMirrorStatusCollector) Collect(ch chan<- prometheus.Metric, version *Version, wg *sync.WaitGroup) {
+	defer wg.Done()
+
 	status, err := rbdMirrorStatus(c.config, c.user)
 	if err != nil {
 		c.logger.WithError(err).Error("failed to run 'rbd mirror pool status'")

--- a/ceph/rgw.go
+++ b/ceph/rgw.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -217,7 +218,9 @@ func (r *RGWCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect sends all the collected metrics to the provided prometheus channel.
 // It requires the caller to handle synchronization.
-func (r *RGWCollector) Collect(ch chan<- prometheus.Metric, version *Version) {
+func (r *RGWCollector) Collect(ch chan<- prometheus.Metric, version *Version, wg *sync.WaitGroup) {
+	defer wg.Done()
+
 	if !r.background {
 		r.logger.WithField("background", r.background).Debug("collecting RGW GC stats")
 		err := r.collect()


### PR DESCRIPTION
- Sets `client_mount_timeout` to the value of `CEPH_RADOS_OP_TIMEOUT`, while also having a goroutine-based timeout of the same interval. This is because ceph's client_mount_timeout may be retried 10 times, so a 30 second timeout is actually 5 minutes (we only set the ceph timeout to clear out resource leaks).

- All our collectors are now run asynchronously in goroutines. This prevents the scrape as a whole from exceeding the timeout (in rare cases where mons die mid-scrape), as all ceph commands will run at the same time. This also reduces scrape time by a considerable amount.