### PR TITLE
Fail to start if any rados connection fails on startup

### DIFF
--- a/main.go
+++ b/main.go
@@ -127,8 +127,7 @@ func main() {
 			logger)
 
 		if err != nil {
-			logger.WithError(err).WithField("cluster", cluster.ClusterLabel).Error("unable to create rados connection for cluster")
-			continue
+			logger.WithError(err).WithField("cluster", cluster.ClusterLabel).Fatal("unable to create rados connection for cluster")
 		}
 
 		prometheus.MustRegister(ceph.NewExporter(


### PR DESCRIPTION
Not instantiating an exporter and logging instead of failing to start when we can't connect to one of the configured clusters is not the behaviour we want; a user may think that ceph_exporter is monitoring all of the requested clusters (since it's up and responds to metrics requests) when in fact data is missing.