### PR TITLE
rgw: add ability to track reshard stats

### DIFF
--- a/ceph/exporter.go
+++ b/ceph/exporter.go
@@ -181,9 +181,7 @@ func (exporter *Exporter) setRbdMirror() error {
 		}
 	} else {
 		// remove the rbdMirror collector if present
-		if _, ok := exporter.cc["rbdMirror"]; ok {
-			delete(exporter.cc, "rbdMirror")
-		}
+		delete(exporter.cc, "rbdMirror")
 	}
 
 	return nil


### PR DESCRIPTION
This adds ability to track RGW reshard stats for tracking when a bucket is being actively resharded. We should also be able to see the count of active reshards at any given time.